### PR TITLE
Allow associating targettype with LayoutDescriptorBase

### DIFF
--- a/src/FlatFile.Core/Base/LayoutDescriptorBase.cs
+++ b/src/FlatFile.Core/Base/LayoutDescriptorBase.cs
@@ -13,7 +13,9 @@ namespace FlatFile.Core.Base
             FieldsContainer = fieldsContainer;
         }
 
-        public virtual Type TargetType { get { throw new NotImplementedException(); } }
+        public LayoutDescriptorBase(IFieldsContainer<TFieldSettings> fieldsContainer, Type targetType) : this(fieldsContainer) { TargetType = targetType; }
+
+        public virtual Type TargetType { get; private set; }
 
         public IEnumerable<TFieldSettings> Fields
         {

--- a/src/FlatFile.FixedLength.Attributes/Infrastructure/FixedLayoutDescriptorProvider.cs
+++ b/src/FlatFile.FixedLength.Attributes/Infrastructure/FixedLayoutDescriptorProvider.cs
@@ -41,10 +41,7 @@ namespace FlatFile.FixedLength.Attributes.Infrastructure
                 }
             }
 
-            var descriptor = new LayoutDescriptorBase<IFixedFieldSettingsContainer>(container)
-            {
-                HasHeader = false
-            };
+            var descriptor = new LayoutDescriptorBase<IFixedFieldSettingsContainer>(container, t) {HasHeader = false};
 
             return descriptor;
         }


### PR DESCRIPTION
This fixes a major bug I missed when using the factory to get a multi-record engine using an array of types rather than layouts. Without this fix, using an array of types throws a `NotImplementedException`.