### PR TITLE
First crack at POC for #19

### DIFF
--- a/src/FlatFile.Core/Extensions/ReflectionHelper.cs
+++ b/src/FlatFile.Core/Extensions/ReflectionHelper.cs
@@ -1,38 +1,87 @@
-﻿namespace FlatFile.Core.Extensions
+﻿using System.Linq;
+using System.Reflection;
+
+namespace FlatFile.Core.Extensions
 {
     using System;
     using System.Collections.Generic;
     using System.Linq.Expressions;
 
+    /// <summary>
+    /// Class ReflectionHelper.
+    /// </summary>
     public static class ReflectionHelper
     {
         static readonly object CacheLock = new object();
-        static readonly Dictionary<Type, object> Cache = new Dictionary<Type, object>();
+        static readonly Dictionary<ConstructorInfo, Func<object>> Cache = new Dictionary<ConstructorInfo, Func<object>>();
 
-        public static T CreateInstance<T>(bool cached = false)
-        {
-            return (T)CreateInstance(typeof(T), cached);
-        }
+        /// <summary>
+        /// Creates an instance of type <typeparamref name="T"/> using the default constructor.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="cached">if set to <c>true</c> [cached].</param>
+        /// <returns>T.</returns>
+        public static T CreateInstance<T>(bool cached = false) { return (T) CreateInstance(typeof (T), cached); }
 
+        /// <summary>
+        /// Creates an instance of type <paramref name="targetType"/> using the default constructor.
+        /// </summary>
+        /// <param name="targetType">Type of the target.</param>
+        /// <param name="cached">if set to <c>true</c> [cached].</param>
+        /// <returns>System.Object.</returns>
         public static object CreateInstance(Type targetType, bool cached = false)
         {
             if (targetType == null) return null;
 
-            object value;
+            var ctorInfo = targetType.GetConstructor(Type.EmptyTypes);
+
+            return CreateInstance(ctorInfo, cached);
+        }
+
+        /// <summary>
+        /// Creates an instance of type <paramref name="targetType"/> using the specified constructor parameters.
+        /// </summary>
+        /// <param name="targetType">Type of the target.</param>
+        /// <param name="cached">if set to <c>true</c> [cached].</param>
+        /// <param name="parameters">The constructor arguments.</param>
+        /// <returns>System.Object.</returns>
+        public static object CreateInstance(Type targetType, bool cached = false, params object[] parameters)
+        {
+            if (targetType == null) return null;
+            if (parameters == null || !parameters.Any()) return CreateInstance(targetType, cached);
+
+            var ctorInfo = targetType.GetConstructor(parameters.Select(a => a.GetType()).ToArray());
+
+            return CreateInstance(ctorInfo, cached, parameters);
+        }
+
+        static object CreateInstance(ConstructorInfo ctorInfo, bool cached, object[] parameters = null)
+        {
+            if (ctorInfo == null) return null;
+            var hasArguments = parameters != null && parameters.Any();
+
+            Func<object> ctor;
             lock (CacheLock)
             {
-                if (!Cache.TryGetValue(targetType, out value) || !cached)
+                if (!Cache.TryGetValue(ctorInfo, out ctor) || !cached)
                 {
-                    value = ((Func<object>)Expression.Lambda(Expression.New(targetType)).Compile())();
+                    if (hasArguments)
+                    {
+                        var ctorArgs = ctorInfo.GetParameters().Select((param, index) => Expression.Parameter(param.ParameterType, String.Format("Param{0}", index))).ToArray();
+                        // ReSharper disable once CoVariantArrayConversion
+                        ctor = (Func<object>) Expression.Lambda(Expression.New(ctorInfo, ctorArgs), ctorArgs).Compile();
+                    }
+                    else
+                    {
+                        ctor = (Func<object>) Expression.Lambda(Expression.New(ctorInfo)).Compile();
+                    }
                 }
 
-                if (cached && !Cache.ContainsKey(targetType))
-                {
-                    Cache.Add(targetType, value);
-                }  
+                if (cached) CacheCtor(ctorInfo, ctor);
             }
-
-            return value;
+            return hasArguments ? ctor.DynamicInvoke(parameters) : ctor();
         }
+
+        static void CacheCtor(ConstructorInfo key, Func<object> ctor) { if (!Cache.ContainsKey(key)) Cache.Add(key, ctor); }
     }
 }

--- a/src/FlatFile.FixedLength/IFixedLengthLineParserFactory.cs
+++ b/src/FlatFile.FixedLength/IFixedLengthLineParserFactory.cs
@@ -1,9 +1,30 @@
+using System;
+using FlatFile.Core.Base;
+
 namespace FlatFile.FixedLength
 {
     using FlatFile.Core;
 
+    /// <summary>
+    /// Interface IFixedLengthLineParserFactory
+    /// </summary>
     public interface IFixedLengthLineParserFactory :
         ILineParserFactory<IFixedLengthLineParser, ILayoutDescriptor<IFixedFieldSettingsContainer>, IFixedFieldSettingsContainer>
     {
+        /// <summary>
+        /// Registers the line parser <typeparamref name="TParser" /> for lines matching <paramref name="targetType" />.
+        /// </summary>
+        /// <typeparam name="TParser">The type of the t parser.</typeparam>
+        /// <param name="targetType">The target record type.</param>
+        /// <exception cref="System.NotImplementedException"></exception>
+        void RegisterLineParser<TParser>(Type targetType) where TParser : IFixedLengthLineParser;
+
+        /// <summary>
+        /// Registers the line parser <typeparamref name="TParser" /> for lines matching <paramref name="targetLayout" />.
+        /// </summary>
+        /// <typeparam name="TParser">The type of the t parser.</typeparam>
+        /// <param name="targetLayout">The target layout.</param>
+        /// <exception cref="System.NotImplementedException"></exception>
+        void RegisterLineParser<TParser>(ILayoutDescriptor<IFieldSettings> targetLayout) where TParser : IFixedLengthLineParser;
     }
 }

--- a/src/FlatFile.FixedLength/Implementation/FixedLengthFileEngineFactory.cs
+++ b/src/FlatFile.FixedLength/Implementation/FixedLengthFileEngineFactory.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using FlatFile.Core.Base;
 
 namespace FlatFile.FixedLength.Implementation
 {
@@ -10,6 +11,30 @@ namespace FlatFile.FixedLength.Implementation
     /// </summary>
     public class FixedLengthFileEngineFactory : IFlatFileEngineFactory<ILayoutDescriptor<IFixedFieldSettingsContainer>, IFixedFieldSettingsContainer>
     {
+        readonly FixedLengthLineParserFactory lineParserFactory = new FixedLengthLineParserFactory();
+
+        /// <summary>
+        /// Registers the line parser <typeparamref name="TParser" /> for lines matching <paramref name="targetType" />.
+        /// </summary>
+        /// <typeparam name="TParser">The type of the t parser.</typeparam>
+        /// <param name="targetType">The target record type.</param>
+        /// <exception cref="System.NotImplementedException"></exception>
+        public void RegisterLineParser<TParser>(Type targetType) where TParser : IFixedLengthLineParser
+        {
+            lineParserFactory.RegisterLineParser<TParser>(targetType);
+        }
+
+        /// <summary>
+        /// Registers the line parser <typeparamref name="TParser" /> for lines matching <paramref name="targetLayout" />.
+        /// </summary>
+        /// <typeparam name="TParser">The type of the t parser.</typeparam>
+        /// <param name="targetLayout">The target layout.</param>
+        /// <exception cref="System.NotImplementedException"></exception>
+        public void RegisterLineParser<TParser>(ILayoutDescriptor<IFieldSettings> targetLayout) where TParser : IFixedLengthLineParser
+        {
+            lineParserFactory.RegisterLineParser<TParser>(targetLayout);
+        }
+
         /// <summary>
         /// Gets the <see cref="IFlatFileEngine" />.
         /// </summary>
@@ -23,7 +48,7 @@ namespace FlatFile.FixedLength.Implementation
             return new FixedLengthFileEngine(
                 descriptor, 
                 new FixedLengthLineBuilderFactory(),
-                new FixedLengthLineParserFactory(), 
+                lineParserFactory, 
                 handleEntryReadError);
         }
 
@@ -43,7 +68,7 @@ namespace FlatFile.FixedLength.Implementation
                 layoutDescriptors,
                 typeSelectorFunc,
                 new FixedLengthLineBuilderFactory(),
-                new FixedLengthLineParserFactory(),
+                lineParserFactory,
                 handleEntryReadError);
         }
     }

--- a/src/FlatFile.FixedLength/Implementation/FixedLengthFileMultiEngine.cs
+++ b/src/FlatFile.FixedLength/Implementation/FixedLengthFileMultiEngine.cs
@@ -59,7 +59,7 @@ namespace FlatFile.FixedLength.Implementation
             if (typeSelectorFunc == null) throw new ArgumentNullException("typeSelectorFunc");
             this.layoutDescriptors = layoutDescriptors.ToList();
             results = new Dictionary<Type, ArrayList>(this.layoutDescriptors.Count());
-            foreach (var descriptor in layoutDescriptors)
+            foreach (var descriptor in this.layoutDescriptors)
             {
                 results[descriptor.TargetType] = new ArrayList();
             }
@@ -150,7 +150,7 @@ namespace FlatFile.FixedLength.Implementation
                 // Use selector func to find type for this line, and by effect, its layout
                 var type = typeSelectorFunc(line);
                 if (type == null) continue;
-                var entry = ReflectionHelper.CreateInstance(type);
+                var entry = ReflectionHelper.CreateInstance(type, true);
 
                 try
                 {

--- a/src/FlatFile.FixedLength/Implementation/FixedLengthLineParserFactory.cs
+++ b/src/FlatFile.FixedLength/Implementation/FixedLengthLineParserFactory.cs
@@ -1,12 +1,72 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FlatFile.Core.Base;
+using FlatFile.Core.Extensions;
+
 namespace FlatFile.FixedLength.Implementation
 {
-    using FlatFile.Core;
+    using Core;
 
+    /// <summary>
+    /// Class FixedLengthLineParserFactory.
+    /// </summary>
     public class FixedLengthLineParserFactory : IFixedLengthLineParserFactory
     {
+        readonly Dictionary<Type, Type> lineParserRegistry;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FixedLengthLineParserFactory"/> class.
+        /// </summary>
+        public FixedLengthLineParserFactory() { lineParserRegistry = new Dictionary<Type, Type>(); }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FixedLengthLineParserFactory"/> class.
+        /// </summary>
+        /// <param name="lineParserRegistry">The line parser registry.</param>
+        public FixedLengthLineParserFactory(IDictionary<Type, Type> lineParserRegistry) { this.lineParserRegistry = new Dictionary<Type, Type>(lineParserRegistry); }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FixedLengthLineParserFactory"/> class.
+        /// </summary>
+        /// <param name="lineParserRegistry">The line parser registry.</param>
+        public FixedLengthLineParserFactory(IDictionary<Type, ILayoutDescriptor<IFixedFieldSettingsContainer>> lineParserRegistry)
+        {
+            this.lineParserRegistry = lineParserRegistry.ToDictionary(descriptor => descriptor.Key, descriptor => descriptor.Value.TargetType);
+        }
+
+        /// <summary>
+        /// Gets the parser.
+        /// </summary>
+        /// <param name="descriptor">The descriptor.</param>
+        /// <returns>IFixedLengthLineParser.</returns>
         public IFixedLengthLineParser GetParser(ILayoutDescriptor<IFixedFieldSettingsContainer> descriptor)
         {
-            return new FixedLengthLineParser(descriptor);
+            if (descriptor == null) throw new ArgumentNullException("descriptor");
+
+            return descriptor.TargetType != null && lineParserRegistry.ContainsKey(descriptor.TargetType)
+                       ? (IFixedLengthLineParser) ReflectionHelper.CreateInstance(lineParserRegistry[descriptor.TargetType], true, descriptor)
+                       : new FixedLengthLineParser(descriptor);
+        }
+
+        /// <summary>
+        /// Registers the line parser <typeparamref name="TParser" /> for lines matching <paramref name="targetType" />.
+        /// </summary>
+        /// <typeparam name="TParser">The type of the t parser.</typeparam>
+        /// <param name="targetType">The target record type.</param>
+        public void RegisterLineParser<TParser>(Type targetType) where TParser : IFixedLengthLineParser
+        {
+            lineParserRegistry[targetType] = typeof (TParser);
+        }
+
+        /// <summary>
+        /// Registers the line parser <typeparamref name="TParser" /> for lines matching <paramref name="targetLayout" />.
+        /// </summary>
+        /// <typeparam name="TParser">The type of the t parser.</typeparam>
+        /// <param name="targetLayout">The target layout.</param>
+        public void RegisterLineParser<TParser>(ILayoutDescriptor<IFieldSettings> targetLayout) where TParser : IFixedLengthLineParser
+        {
+            lineParserRegistry[targetLayout.TargetType] = typeof (TParser);
         }
     }
 }


### PR DESCRIPTION
Implements a solution for #19 
Improvements to ReflectionHelper

- Cache Func<> to create instance rather than the instance inself
- Cache based on ConstructorInfo rather than Type to allow paramaterized
  constructors
- Support paramaterized constructors
- Switch from Func<object>->Delegate to remove compile-time dependency on the number of ctor arguments