### PR TITLE
Blank lines or lines that are shorter than the definition throw an error

### DIFF
--- a/src/FlatFile.Core/Base/FlatFileEngine.cs
+++ b/src/FlatFile.Core/Base/FlatFileEngine.cs
@@ -67,6 +67,8 @@ namespace FlatFile.Core.Base
 
             while ((line = reader.ReadLine()) != null)
             {
+                if (string.IsNullOrEmpty(line) || string.IsNullOrEmpty(line.Trim())) continue;
+                
                 bool ignoreEntry = false;
                 var entry = new TEntity();
                 try

--- a/src/FlatFile.FixedLength/Implementation/FixedLengthLineParser.cs
+++ b/src/FlatFile.FixedLength/Implementation/FixedLengthLineParser.cs
@@ -42,8 +42,8 @@ namespace FlatFile.FixedLength.Implementation
                 }
 
                 throw new IndexOutOfRangeException(
-                    $"The field at {field.Index} with a length of {field.Length} cannot be found on the line because the line is too short. " +
-                    "Setting a NullValue for this field will allow the line to be parsed and this field to be null.");
+                    string.Format("The field at {0} with a length of {1} cannot be found on the line because the line is too short. " +
+                    "Setting a NullValue for this field will allow the line to be parsed and this field to be null.", field.Index, field.Length));
             }
 
             return line.Substring(linePosition, field.Length);

--- a/src/FlatFile.FixedLength/Implementation/FixedLengthLineParser.cs
+++ b/src/FlatFile.FixedLength/Implementation/FixedLengthLineParser.cs
@@ -42,8 +42,8 @@ namespace FlatFile.FixedLength.Implementation
                 }
 
                 throw new IndexOutOfRangeException(
-                    $"The field at {field.Index} with a length of {field.Length} cannot be found on the line because the line is too short." +
-                    "Setting IsNullable to true will allow the line to be parsed");
+                    $"The field at {field.Index} with a length of {field.Length} cannot be found on the line because the line is too short. " +
+                    "Setting a NullValue for this field will allow the line to be parsed and this field to be null.");
             }
 
             return line.Substring(linePosition, field.Length);

--- a/src/FlatFile.Tests/FixedLength/FixedLengthLineParserTests.cs
+++ b/src/FlatFile.Tests/FixedLength/FixedLengthLineParserTests.cs
@@ -34,5 +34,20 @@
             parsedEntity.Description.Should().Be(description);
             parsedEntity.NullableInt.Should().Be(nullableInt);
         }
+
+        [Theory]
+        [InlineData("00001Description 1            00003", 1, "Description 1", 3)]
+        [InlineData("00005Description 5            ", 5, "Description 5", null)]
+        [InlineData("00005Description 5            3", 5, "Description 5", 3)]
+        public void ParserShouldSetValueNullValueIfStringIsToShort(string inputString, int id, string description, int? nullableInt)
+        {
+            var entry = new TestObject();
+
+            var parsedEntity = parser.ParseLine(inputString, entry);
+
+            parsedEntity.Id.Should().Be(id);
+            parsedEntity.Description.Should().Be(description);
+            parsedEntity.NullableInt.Should().Be(nullableInt);
+        }
     }
 }


### PR DESCRIPTION
I found that if the line on the Flat file is shorter than defined for the file, an index out of range exception occurs.  

I modified the code to trap for this condition.  If the field has a NullValue defined, then the code will set it to null.  If not, it will throw an error with a better message to help troubleshoot.

I also found the same error if the line was empty.  I have found in many import files this can occur and cannot be controlled by the generating system.  I have modified the code to ignore empty lines.