### PR TITLE
resolves #36

### DIFF
--- a/src/FlatFile.FixedLength.Attributes/FixedLengthFieldAttribute.cs
+++ b/src/FlatFile.FixedLength.Attributes/FixedLengthFieldAttribute.cs
@@ -1,5 +1,6 @@
 ﻿namespace FlatFile.FixedLength.Attributes
 {
+    using System;
     using FlatFile.Core.Attributes.Base;
 
     public class FixedLengthFieldAttribute : FieldSettingsBaseAttribute, IFixedFieldSettings
@@ -15,11 +16,13 @@
 
         public char PaddingChar { get; set; }
 
-        public FixedLengthFieldAttribute(int index, int length)
+        public bool TruncateIfExceedFieldLength { get; set; }
+
+        public FixedLengthFieldAttribute(int index, int length, bool truncateIfExceed = false)
             : base(index)
         {
             Padding = Padding.Left;
-
+            TruncateIfExceedFieldLength = truncateIfExceed;
             Length = length;
         }
     }

--- a/src/FlatFile.FixedLength/FixedFieldSettings.cs
+++ b/src/FlatFile.FixedLength/FixedFieldSettings.cs
@@ -8,6 +8,8 @@ namespace FlatFile.FixedLength
         int Length { get; }
         bool PadLeft { get; }
         char PaddingChar { get; }
+        bool TruncateIfExceedFieldLength { get; }
+
     }
 
     public interface IFixedFieldSettingsContainer : IFixedFieldSettings, IFieldSettingsContainer
@@ -27,6 +29,7 @@ namespace FlatFile.FixedLength
             PadLeft = settings.PadLeft;
             PaddingChar = settings.PaddingChar;
             TypeConverter = settings.TypeConverter;
+            TruncateIfExceedFieldLength = settings.TruncateIfExceedFieldLength;
         }
 
         public FixedFieldSettings(PropertyInfo propertyInfo, IFixedFieldSettings settings)
@@ -38,5 +41,6 @@ namespace FlatFile.FixedLength
         public int Length { get; set; }
         public bool PadLeft { get; set; }
         public char PaddingChar { get; set; }
+        public bool TruncateIfExceedFieldLength { get; set; }
     }
 }

--- a/src/FlatFile.FixedLength/IFixedFieldSettingsConstructor.cs
+++ b/src/FlatFile.FixedLength/IFixedFieldSettingsConstructor.cs
@@ -14,5 +14,7 @@ namespace FlatFile.FixedLength
         IFixedFieldSettingsConstructor WithLeftPadding(char paddingChar);
 
         IFixedFieldSettingsConstructor WithRightPadding(char paddingChar);
+
+        IFixedFieldSettingsConstructor TruncateFieldContentIfExceedLength();
     }
 }

--- a/src/FlatFile.FixedLength/Implementation/FixedFieldSettingsConstructor.cs
+++ b/src/FlatFile.FixedLength/Implementation/FixedFieldSettingsConstructor.cs
@@ -11,6 +11,12 @@ namespace FlatFile.FixedLength.Implementation
         {
         }
 
+        public IFixedFieldSettingsConstructor TruncateFieldContentIfExceedLength()
+        {
+            TruncateIfExceedFieldLength = true;
+            return this;
+        }
+
         public IFixedFieldSettingsConstructor WithLength(int length)
         {
             Length = length;

--- a/src/FlatFile.FixedLength/Implementation/FixedLengthLineBuilder.cs
+++ b/src/FlatFile.FixedLength/Implementation/FixedLengthLineBuilder.cs
@@ -24,7 +24,7 @@ namespace FlatFile.FixedLength.Implementation
         {
             if (lineValue.Length >= field.Length)
             {
-                return lineValue;
+                return field.TruncateIfExceedFieldLength ? lineValue.Substring(0, field.Length) : lineValue;
             }
 
             lineValue = field.PadLeft


### PR DESCRIPTION
As requested in issue #36:
- added a setting to set if a field must be truncated if its content exceeds the maximum length
- truncated the string if the setting it's true