### PR TITLE
Issue #47 - Implementation of DelimitedFileMultiEngine.

### DIFF
--- a/src/FlatFile.Delimited.Attributes/FlatFileEngineFactoryExtensions.cs
+++ b/src/FlatFile.Delimited.Attributes/FlatFileEngineFactoryExtensions.cs
@@ -1,4 +1,8 @@
-﻿namespace FlatFile.Delimited.Attributes
+﻿using System.Collections.Generic;
+using System.Linq;
+using FlatFile.Delimited.Implementation;
+
+namespace FlatFile.Delimited.Attributes
 {
     using System;
     using FlatFile.Core;
@@ -7,6 +11,13 @@
 
     public static class FlatFileEngineFactoryExtensions
     {
+        /// <summary>
+        /// Gets the engine.
+        /// </summary>
+        /// <typeparam name="TEntity">The type of the t entity.</typeparam>
+        /// <param name="engineFactory">The engine factory.</param>
+        /// <param name="handleEntryReadError">The handle entry read error.</param>
+        /// <returns>IFlatFileEngine.</returns>
         public static IFlatFileEngine GetEngine<TEntity>(
             this IFlatFileEngineFactory<IDelimitedLayoutDescriptor, IDelimitedFieldSettingsContainer> engineFactory,
             Func<string, Exception, bool> handleEntryReadError = null)
@@ -17,6 +28,25 @@
             var descriptor = descriptorProvider.GetDescriptor<TEntity>();
 
             return engineFactory.GetEngine(descriptor, handleEntryReadError);
+        }
+
+        /// <summary>
+        /// Gets the engine.
+        /// </summary>
+        /// <param name="engineFactory">The engine factory.</param>
+        /// <param name="recordTypes">The record types.</param>
+        /// <param name="typeSelectorFunc">The type selector function.</param>
+        /// <param name="handleEntryReadError">The handle entry read error.</param>
+        /// <returns>IFlatFileMultiEngine.</returns>
+        public static IFlatFileMultiEngine GetEngine(
+            this DelimitedFileEngineFactory engineFactory,
+            IEnumerable<Type> recordTypes,
+            Func<string, Type> typeSelectorFunc,
+            Func<string, Exception, bool> handleEntryReadError = null)
+        {
+            var descriptorProvider = new DelimitedLayoutDescriptorProvider();
+            var descriptors = recordTypes.Select(type => descriptorProvider.GetDescriptor(type)).ToList();
+            return engineFactory.GetEngine(descriptors, typeSelectorFunc, handleEntryReadError);
         }
     }
 }

--- a/src/FlatFile.Delimited.Attributes/Infrastructure/DelimitedLayoutDescriptorProvider.cs
+++ b/src/FlatFile.Delimited.Attributes/Infrastructure/DelimitedLayoutDescriptorProvider.cs
@@ -2,18 +2,25 @@
 {
     using System;
     using System.Linq;
+    using FlatFile.Core;
     using FlatFile.Core.Attributes.Extensions;
     using FlatFile.Core.Attributes.Infrastructure;
     using FlatFile.Core.Base;
     using FlatFile.Delimited.Implementation;
+    
 
     public class DelimitedLayoutDescriptorProvider : ILayoutDescriptorProvider<IDelimitedFieldSettingsContainer, IDelimitedLayoutDescriptor>
     {
         public IDelimitedLayoutDescriptor GetDescriptor<T>()
         {
+            return GetDescriptor(typeof(T));
+        }
+
+        public IDelimitedLayoutDescriptor GetDescriptor(Type t)
+        {
             var container = new FieldsContainer<IDelimitedFieldSettingsContainer>();
 
-            var fileMappingType = typeof (T);
+            var fileMappingType = t;
 
             var fileAttribute = fileMappingType.GetAttribute<DelimitedFileAttribute>();
 
@@ -21,7 +28,7 @@
             {
                 throw new NotSupportedException(string.Format("Mapping type {0} should be marked with {1} attribute",
                     fileMappingType.Name,
-                    typeof (DelimitedFileAttribute).Name));
+                    typeof(DelimitedFileAttribute).Name));
             }
 
             var properties = fileMappingType.GetTypeDescription<DelimitedFieldAttribute>();
@@ -35,17 +42,44 @@
                     container.AddOrUpdate(p.Property, new DelimitedFieldSettings(p.Property, settings));
                 }
             }
+            
 
-            var descriptor = new DelimitedLayout<T>(new DelimitedFieldSettingsFactory(), container)
+            var methodInfo = typeof(DelimedLayoutGeneric)
+                            .GetMethod("GetDelimitedLayout")
+                            .MakeGenericMethod(new[] { t });
+            object[] args = { null, new DelimitedFieldSettingsFactory(), container, fileAttribute };
+            var descriptor = (IDelimitedLayoutDescriptor)methodInfo.Invoke(null, args);
+            
+            //var descriptor = DelimedLayoutGeneric.GetDelimitedLayout(t, new DelimitedFieldSettingsFactory(), container)
+            //    .WithDelimiter(fileAttribute.Delimiter)
+            //    .WithQuote(fileAttribute.Quotes);
+
+            //if (fileAttribute.HasHeader)
+            //{
+            //    descriptor.WithHeader();
+            //}
+
+            return descriptor;
+        }
+    }
+
+    public class DelimedLayoutGeneric
+    {
+        public static IDelimitedLayoutDescriptor GetDelimitedLayout<TTarget>(TTarget t,
+            IFieldSettingsFactory<IDelimitedFieldSettingsConstructor> fieldSettingsFactory,
+            IFieldsContainer<IDelimitedFieldSettingsContainer> fieldsContainer,
+            DelimitedFileAttribute fileAttribute)
+        {
+            var dl = new DelimitedLayout<TTarget>(fieldSettingsFactory, fieldsContainer)
                 .WithDelimiter(fileAttribute.Delimiter)
                 .WithQuote(fileAttribute.Quotes);
 
             if (fileAttribute.HasHeader)
             {
-                descriptor.WithHeader();
+                dl.WithHeader();
             }
-
-            return descriptor;
+            
+            return dl;
         }
     }
 }

--- a/src/FlatFile.Delimited.Attributes/Infrastructure/DelimitedMultiLayoutDescriptor.cs
+++ b/src/FlatFile.Delimited.Attributes/Infrastructure/DelimitedMultiLayoutDescriptor.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections.Generic;
+
+using FlatFile.Core;
+using FlatFile.Core.Base;
+using FlatFile.Core.Attributes.Extensions;
+using FlatFile.Core.Attributes.Infrastructure;
+
+namespace FlatFile.Delimited.Attributes.Infrastructure
+{
+    public class DelimitedMultiLayoutDescriptor<TFieldSettings> : ILayoutDescriptorProvider<TFieldSettings, ILayoutDescriptor<TFieldSettings>>
+        where TFieldSettings : IDelimitedFieldSettingsContainer
+    {
+        protected IFieldsContainer<TFieldSettings> FieldsContainer { get; private set; }
+
+        public DelimitedMultiLayoutDescriptor(IFieldsContainer<TFieldSettings> fieldsContainer)
+        {
+            FieldsContainer = fieldsContainer;
+        }
+
+        public DelimitedMultiLayoutDescriptor(IFieldsContainer<TFieldSettings> fieldsContainer, Type targetType) : this(fieldsContainer) { TargetType = targetType; }
+
+        ILayoutDescriptor<TFieldSettings> ILayoutDescriptorProvider<TFieldSettings, ILayoutDescriptor<TFieldSettings>>.GetDescriptor<T>()
+        {
+            throw new NotImplementedException();
+        }
+
+        public virtual Type TargetType { get; private set; }
+
+        public IEnumerable<TFieldSettings> Fields
+        {
+            get { return FieldsContainer.OrderedFields; }
+        }
+
+        public bool HasHeader { get; protected internal set; }
+
+
+        public string Delimiter { get; private set; }
+
+        public string Quotes { get; private set; }
+
+        public DelimitedMultiLayoutDescriptor<TFieldSettings> WithQuote(string quote)
+        {
+            Quotes = quote;
+
+            return this;
+        }
+
+        public DelimitedMultiLayoutDescriptor<TFieldSettings> WithDelimiter(string delimiter)
+        {
+            Delimiter = delimiter;
+
+            return this;
+        }
+
+ 
+    }
+}

--- a/src/FlatFile.Delimited/FlatFile.Delimited.csproj
+++ b/src/FlatFile.Delimited/FlatFile.Delimited.csproj
@@ -101,6 +101,9 @@
     <Compile Include="IDelimitedLineBuilderFactory.cs" />
     <Compile Include="IDelimitedLineParser.cs" />
     <Compile Include="IDelimitedLineParserFactory.cs" />
+    <Compile Include="IDetailRecord.cs" />
+    <Compile Include="IMasterRecord.cs" />
+    <Compile Include="Implementation\DelimetedFileMultiEngine.cs" />
     <Compile Include="Implementation\DelimitedFileEngineFactory.cs" />
     <Compile Include="Implementation\DelimitedFieldSettingsConstructor.cs" />
     <Compile Include="Implementation\DelimitedFieldSettingsFactory.cs" />

--- a/src/FlatFile.Delimited/IDetailRecord.cs
+++ b/src/FlatFile.Delimited/IDetailRecord.cs
@@ -1,0 +1,12 @@
+﻿namespace FlatFile.Delimited
+{
+    /// <summary>
+    /// Interface IDetailRecord
+    /// </summary>
+    /// <remarks>
+    /// Used to decorate a record as a detail type in a master/detail relationship
+    /// </remarks>
+    public interface IDetailRecord
+    {
+    }
+}

--- a/src/FlatFile.Delimited/IMasterRecord.cs
+++ b/src/FlatFile.Delimited/IMasterRecord.cs
@@ -1,0 +1,23 @@
+﻿using System.Collections.Generic;
+using FlatFile.Core;
+
+namespace FlatFile.Delimited
+{
+    /// <summary>
+    /// Interface IMasterRecord
+    /// </summary>
+    /// <remarks>
+    /// Used to decorate a record as a master type in a master/detail relationship.
+    /// </remarks>
+    public interface IMasterRecord
+    {
+        /// <summary>
+        /// Gets the detail records.
+        /// </summary>
+        /// <value>The detail records.</value>
+        /// <remarks>
+        /// This list will be populated with related detail records when parsing a fixed length file with the <see cref="IFlatFileMultiEngine"/>
+        /// </remarks>
+        IList<IDetailRecord> DetailRecords { get; }
+    }
+}

--- a/src/FlatFile.Delimited/Implementation/DelimetedFileMultiEngine.cs
+++ b/src/FlatFile.Delimited/Implementation/DelimetedFileMultiEngine.cs
@@ -1,0 +1,228 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using FlatFile.Core;
+using FlatFile.Core.Base;
+using FlatFile.Core.Exceptions;
+using FlatFile.Core.Extensions;
+
+namespace FlatFile.Delimited.Implementation
+{
+    /// <summary>
+    /// Class DelimetedFileMultiEngine.
+    /// </summary>
+    public class DelimitedFileMultiEngine : FlatFileEngine<IDelimitedFieldSettingsContainer, ILayoutDescriptor<IDelimitedFieldSettingsContainer>>, IFlatFileMultiEngine
+    {
+        /// <summary>
+        /// The handle entry read error func
+        /// </summary>
+        readonly Func<string, Exception, bool> handleEntryReadError;
+        /// <summary>
+        /// The layout descriptors for this engine
+        /// </summary>
+        readonly List<IDelimitedLayoutDescriptor> layoutDescriptors;
+        /// <summary>
+        /// The line builder factory
+        /// </summary>
+        readonly IDelimitedLineBuilderFactory lineBuilderFactory;
+        /// <summary>
+        /// The line parser factory
+        /// </summary>
+        readonly IDelimitedLineParserFactory lineParserFactory;
+        /// <summary>
+        /// The type selector function used to determine the layout for a given line
+        /// </summary>
+        readonly Func<string, Type> typeSelectorFunc;
+        /// <summary>
+        /// The results of a call to <see cref="Read"/> are stored in this Dictionary by type
+        /// </summary>
+        readonly Dictionary<Type, ArrayList> results;
+        /// <summary>
+        /// The last record parsed that implements <see cref="IMasterRecord"/>
+        /// </summary>
+        IMasterRecord lastMasterRecord;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DelimetedFileMultiEngine"/> class.
+        /// </summary>
+        /// <param name="layoutDescriptors">The layout descriptors.</param>
+        /// <param name="typeSelectorFunc">The type selector function.</param>
+        /// <param name="lineBuilderFactory">The line builder factory.</param>
+        /// <param name="lineParserFactory">The line parser factory.</param>
+        /// <param name="handleEntryReadError">The handle entry read error.</param>
+        /// <exception cref="System.ArgumentNullException">typeSelectorFunc</exception>
+        internal DelimitedFileMultiEngine(
+            IEnumerable<IDelimitedLayoutDescriptor> layoutDescriptors,
+            Func<string, Type> typeSelectorFunc,
+            IDelimitedLineBuilderFactory lineBuilderFactory,
+            IDelimitedLineParserFactory lineParserFactory,
+            Func<string, Exception, bool> handleEntryReadError = null)
+        {
+            if (typeSelectorFunc == null) throw new ArgumentNullException("typeSelectorFunc");
+            this.layoutDescriptors = layoutDescriptors.ToList();
+            results = new Dictionary<Type, ArrayList>(this.layoutDescriptors.Count());
+            foreach (var descriptor in this.layoutDescriptors)
+            {
+                results[descriptor.TargetType] = new ArrayList();
+            }
+            this.typeSelectorFunc = typeSelectorFunc;
+            this.lineBuilderFactory = lineBuilderFactory;
+            this.lineParserFactory = lineParserFactory;
+            this.handleEntryReadError = handleEntryReadError;
+        }
+
+        /// <summary>
+        /// Gets the line builder.
+        /// </summary>
+        /// <value>The line builder.</value>
+        /// <remarks>The <see cref="DelimitedFileMultiEngine"/> does not contain just a single line builder.</remarks>
+        /// <exception cref="System.NotImplementedException"></exception>
+        protected override ILineBulder LineBuilder { get { throw new NotImplementedException(); } }
+
+        /// <summary>
+        /// Gets the line parser.
+        /// </summary>
+        /// <value>The line parser.</value>
+        /// <remarks>The <see cref="FixedLengthFileMultiEngine"/> does not contain just a single line parser.</remarks>
+        /// <exception cref="System.NotImplementedException"></exception>
+        protected override ILineParser LineParser { get { throw new NotImplementedException(); } }
+
+        /// <summary>
+        /// Gets the layout descriptor.
+        /// </summary>
+        /// <remarks>The <see cref="DelimitedFileMultiEngine"/> does not contain just a single layout.</remarks>
+        /// <value>The layout descriptor.</value>
+        /// <exception cref="System.NotImplementedException"></exception>
+        protected override ILayoutDescriptor<IDelimitedFieldSettingsContainer> LayoutDescriptor { get { throw new NotImplementedException(); } }
+
+        /// <summary>
+        /// Gets any records of type <typeparamref name="T" /> read by <see cref="Read" />.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <returns>IEnumerable&lt;T&gt;.</returns>
+        public IEnumerable<T> GetRecords<T>() where T : class, new()
+        {
+            return !results.ContainsKey(typeof(T)) ? new List<T>() : results[typeof(T)].Cast<T>();
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether this instance has a file header.
+        /// </summary>
+        /// <value><c>true</c> if this instance has a file header; otherwise, <c>false</c>.</value>
+        public bool HasHeader { get; set; }
+
+        /// <summary>
+        /// Tries to parse the line.
+        /// </summary>
+        /// <typeparam name="TEntity">The type of the t entity.</typeparam>
+        /// <param name="line">The line.</param>
+        /// <param name="lineNumber">The line number.</param>
+        /// <param name="entity">The entity.</param>
+        /// <returns><c>true</c> if XXXX, <c>false</c> otherwise.</returns>
+        protected override bool TryParseLine<TEntity>(string line, int lineNumber, ref TEntity entity)
+        {
+            var type = entity.GetType();
+            var lineParser = lineParserFactory.GetParser(layoutDescriptors.FirstOrDefault(l => l.TargetType == type));
+            lineParser.ParseLine(line, entity);
+
+            return true;
+        }
+
+        /// <summary>
+        /// Reads the specified stream.
+        /// </summary>
+        /// <param name="stream">The stream.</param>
+        /// <exception cref="ParseLineException">Impossible to parse line</exception>
+        public void Read(Stream stream)
+        {
+            var reader = new StreamReader(stream);
+            string line;
+            var lineNumber = 0;
+
+            // Can't support this in a per layout manner, it has to be for the file/engine as a whole
+            if (HasHeader)
+            {
+                ProcessHeader(reader);
+            }
+
+            while ((line = reader.ReadLine()) != null)
+            {
+                var ignoreEntry = false;
+
+                // Use selector func to find type for this line, and by effect, its layout
+                var type = typeSelectorFunc(line);
+                if (type == null) continue;
+                var entry = ReflectionHelper.CreateInstance(type, true);
+
+                try
+                {
+                    if (!TryParseLine(line, lineNumber++, ref entry))
+                    {
+                        throw new ParseLineException("Impossible to parse line", line, lineNumber);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    if (handleEntryReadError == null)
+                    {
+                        throw;
+                    }
+
+                    if (!handleEntryReadError(line, ex))
+                    {
+                        throw;
+                    }
+
+                    ignoreEntry = true;
+                }
+
+                if (ignoreEntry) continue;
+
+                bool isDetailRecord;
+                HandleMasterDetail(entry, out isDetailRecord);
+
+                if (isDetailRecord) continue;
+
+                results[type].Add(entry);
+            }
+        }
+
+
+        /// <summary>
+        /// Handles any master/detail relationships for this <paramref name="entry"/>.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="entry">The entry.</param>
+        /// <param name="isDetailRecord">if set to <c>true</c> [is detail record] and should not be added to the results dictionary.</param>
+        void HandleMasterDetail<T>(T entry, out bool isDetailRecord)
+        {
+            isDetailRecord = false;
+
+            var masterRecord = entry as IMasterRecord;
+            if (masterRecord != null)
+            {
+                // Found new master record
+                lastMasterRecord = masterRecord;
+                return;
+            }
+
+            // Record is standalone or unassociated detail record
+            if (lastMasterRecord == null) return;
+
+            var detailRecord = entry as IDetailRecord;
+            if (detailRecord == null)
+            {
+                // Record is standalone, reset master
+                lastMasterRecord = null;
+                return;
+            }
+
+            // Add detail record and indicate that it should not be added to the results dictionary
+            lastMasterRecord.DetailRecords.Add(detailRecord);
+            isDetailRecord = true;
+        }
+        
+    }
+}

--- a/src/FlatFile.Delimited/Implementation/DelimitedFileEngineFactory.cs
+++ b/src/FlatFile.Delimited/Implementation/DelimitedFileEngineFactory.cs
@@ -1,4 +1,7 @@
-﻿namespace FlatFile.Delimited.Implementation
+﻿using System.Collections.Generic;
+using FlatFile.Core.Base;
+
+namespace FlatFile.Delimited.Implementation
 {
     using System;
     using FlatFile.Core;
@@ -9,6 +12,31 @@
     public class DelimitedFileEngineFactory :
         IFlatFileEngineFactory<IDelimitedLayoutDescriptor, IDelimitedFieldSettingsContainer>
     {
+
+        readonly DelimitedLineParserFactory lineParserFactory = new DelimitedLineParserFactory();
+
+        /// <summary>
+        /// Registers the line parser <typeparamref name="TParser" /> for lines matching <paramref name="targetType" />.
+        /// </summary>
+        /// <typeparam name="TParser">The type of the t parser.</typeparam>
+        /// <param name="targetType">The target record type.</param>
+        /// <exception cref="System.NotImplementedException"></exception>
+        public void RegisterLineParser<TParser>(Type targetType) where TParser : IDelimitedLineParser
+        {
+            lineParserFactory.RegisterLineParser<TParser>(targetType);
+        }
+
+        /// <summary>
+        /// Registers the line parser <typeparamref name="TParser" /> for lines matching <paramref name="targetLayout" />.
+        /// </summary>
+        /// <typeparam name="TParser">The type of the t parser.</typeparam>
+        /// <param name="targetLayout">The target layout.</param>
+        /// <exception cref="System.NotImplementedException"></exception>
+        public void RegisterLineParser<TParser>(ILayoutDescriptor<IFieldSettings> targetLayout) where TParser : IDelimitedLineParser
+        {
+            lineParserFactory.RegisterLineParser<TParser>(targetLayout);
+        }
+
         /// <summary>
         /// Gets the <see cref="IFlatFileEngine" />.
         /// </summary>
@@ -23,6 +51,28 @@
                 descriptor,
                 new DelimitedLineBuilderFactory(),
                 new DelimitedLineParserFactory(),
+                handleEntryReadError);
+        }
+
+
+
+        /// <summary>
+        /// Gets the <see cref="IFlatFileMultiEngine"/>.
+        /// </summary>
+        /// <param name="layoutDescriptors">The layout descriptors.</param>
+        /// <param name="typeSelectorFunc">The type selector function.</param>
+        /// <param name="handleEntryReadError">The handle entry read error func.</param>
+        /// <returns>IFlatFileMultiEngine.</returns>
+        public IFlatFileMultiEngine GetEngine(
+            IEnumerable<IDelimitedLayoutDescriptor> layoutDescriptors,
+            Func<string, Type> typeSelectorFunc,
+            Func<string, Exception, bool> handleEntryReadError = null)
+        {
+            return new DelimitedFileMultiEngine(
+                layoutDescriptors,
+                typeSelectorFunc,
+                new DelimitedLineBuilderFactory(),
+                lineParserFactory,
                 handleEntryReadError);
         }
     }

--- a/src/FlatFile.Delimited/Implementation/DelimitedLineParser.cs
+++ b/src/FlatFile.Delimited/Implementation/DelimitedLineParser.cs
@@ -1,20 +1,23 @@
 namespace FlatFile.Delimited.Implementation
 {
     using System;
+    using FlatFile.Core;
     using FlatFile.Core.Base;
 
     public class DelimitedLineParser :
         LineParserBase<IDelimitedLayoutDescriptor, IDelimitedFieldSettingsContainer>,
-        IDelimitedLineParser 
-        
+        IDelimitedLineParser
+
     {
         public DelimitedLineParser(IDelimitedLayoutDescriptor layout)
             : base(layout)
         {
         }
 
+
         public override TEntity ParseLine<TEntity>(string line, TEntity entity)
         {
+
             int linePosition = 0;
             int delimiterSize = Layout.Delimiter.Length;
             foreach (var field in Layout.Fields)
@@ -22,7 +25,21 @@ namespace FlatFile.Delimited.Implementation
                 int nextDelimiterIndex = -1;
                 if (line.Length > linePosition + delimiterSize)
                 {
-                    nextDelimiterIndex = line.IndexOf(Layout.Delimiter, linePosition, StringComparison.InvariantCultureIgnoreCase);
+                    if (!String.IsNullOrEmpty(Layout.Quotes)) {
+                        if (Layout.Quotes.Equals(line.Substring(linePosition, Layout.Quotes.Length)))
+                        {
+                            nextDelimiterIndex = line.IndexOf(Layout.Quotes, linePosition + 1, StringComparison.InvariantCultureIgnoreCase);
+                            if (line.Length > nextDelimiterIndex)
+                            {
+                                nextDelimiterIndex = line.IndexOf(Layout.Delimiter, nextDelimiterIndex, StringComparison.InvariantCultureIgnoreCase);
+                            }
+                        }
+                    }
+
+                    if (nextDelimiterIndex == -1)
+                    {
+                        nextDelimiterIndex = line.IndexOf(Layout.Delimiter, linePosition, StringComparison.InvariantCultureIgnoreCase);
+                    }
                 }
                 int fieldLength;
                 if (nextDelimiterIndex > -1)

--- a/src/FlatFile.Delimited/Implementation/DelimitedLineParserFactory.cs
+++ b/src/FlatFile.Delimited/Implementation/DelimitedLineParserFactory.cs
@@ -1,10 +1,76 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FlatFile.Core;
+using FlatFile.Core.Base;
+using FlatFile.Core.Extensions;
+
 namespace FlatFile.Delimited.Implementation
 {
     public class DelimitedLineParserFactory : IDelimitedLineParserFactory
     {
+        readonly Dictionary<Type, Type> lineParserRegistry;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DelimitedLineParserFactory"/> class.
+        /// </summary>
+        public DelimitedLineParserFactory() { lineParserRegistry = new Dictionary<Type, Type>(); }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DelimitedLineParserFactory"/> class.
+        /// </summary>
+        /// <param name="lineParserRegistry">The line parser registry.</param>
+        public DelimitedLineParserFactory(IDictionary<Type, Type> lineParserRegistry) { this.lineParserRegistry = new Dictionary<Type, Type>(lineParserRegistry); }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DelimitedLineParserFactory"/> class.
+        /// </summary>
+        /// <param name="lineParserRegistry">The line parser registry.</param>
+        public DelimitedLineParserFactory(IDictionary<Type, ILayoutDescriptor<IDelimitedFieldSettingsContainer>> lineParserRegistry)
+        {
+            this.lineParserRegistry = lineParserRegistry.ToDictionary(descriptor => descriptor.Key, descriptor => descriptor.Value.TargetType);
+        }
+
         public IDelimitedLineParser GetParser(IDelimitedLayoutDescriptor descriptor)
         {
             return new DelimitedLineParser(descriptor);
         }
+
+        /// <summary>
+        /// Gets the parser.
+        /// </summary>
+        /// <param name="descriptor">The descriptor.</param>
+        /// <returns>IFixedLengthLineParser.</returns>
+        public IDelimitedLineParser GetParser(ILayoutDescriptor<IDelimitedFieldSettingsContainer> descriptor)
+        {
+            if (descriptor == null) throw new ArgumentNullException("descriptor");
+
+            if (!(descriptor is IDelimitedLayoutDescriptor)) throw new ArgumentException("descriptor must be IDelimitedLayoutDescriptor");
+            
+            return descriptor.TargetType != null && lineParserRegistry.ContainsKey(descriptor.TargetType)
+                       ? (IDelimitedLineParser)ReflectionHelper.CreateInstance(lineParserRegistry[descriptor.TargetType], true, descriptor)
+                       : new DelimitedLineParser((IDelimitedLayoutDescriptor)descriptor);
+        }
+        
+        /// <summary>
+        /// Registers the line parser <typeparamref name="TParser" /> for lines matching <paramref name="targetType" />.
+        /// </summary>
+        /// <typeparam name="TParser">The type of the t parser.</typeparam>
+        /// <param name="targetType">The target record type.</param>
+        public void RegisterLineParser<TParser>(Type targetType) where TParser : IDelimitedLineParser
+        {
+            lineParserRegistry[targetType] = typeof(TParser);
+        }
+
+        /// <summary>
+        /// Registers the line parser <typeparamref name="TParser" /> for lines matching <paramref name="targetLayout" />.
+        /// </summary>
+        /// <typeparam name="TParser">The type of the t parser.</typeparam>
+        /// <param name="targetLayout">The target layout.</param>
+        public void RegisterLineParser<TParser>(ILayoutDescriptor<IFieldSettings> targetLayout) where TParser : IDelimitedLineParser
+        {
+            lineParserRegistry[targetLayout.TargetType] = typeof(TParser);
+        }
+
     }
 }

--- a/src/FlatFile.Tests/Delimited/DelimitedMultiEngineTests.cs
+++ b/src/FlatFile.Tests/Delimited/DelimitedMultiEngineTests.cs
@@ -1,0 +1,169 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using FlatFile.Core;
+using FlatFile.Delimited;
+using FlatFile.Delimited.Attributes;
+using FlatFile.Delimited.Implementation;
+using FluentAssertions;
+using Xunit;
+
+namespace FlatFile.Tests.Delimited
+{
+    public class DelimitedMultiEngineTests
+    {
+        readonly IFlatFileMultiEngine engine;
+
+        const string TestData = 
+@"S,Test Description,00042
+D,20150323,Another Description";
+
+        [DelimitedFile(Delimiter = ",", HasHeader = false)]
+        class Record1
+        {
+            [DelimitedField(1)]
+            public char Type { get; set; }
+
+            [DelimitedField(2)]
+            public string Description { get; set; }
+
+            [DelimitedField(3)]
+            public int Value { get; set; }
+
+            public Record1() { Type = 'S'; }
+
+            bool Equals(Record1 other) { return Type == other.Type && string.Equals(Description, other.Description) && Value == other.Value; }
+
+            public override int GetHashCode()
+            {
+                unchecked
+                {
+                    var hashCode = Type.GetHashCode();
+                    hashCode = (hashCode * 397) ^ (Description != null ? Description.GetHashCode() : 0);
+                    hashCode = (hashCode * 397) ^ Value;
+                    return hashCode;
+                }
+            }
+
+            public override bool Equals(object obj)
+            {
+                if (ReferenceEquals(null, obj)) return false;
+                if (ReferenceEquals(this, obj)) return true;
+                return obj.GetType() == GetType() && Equals((Record1)obj);
+            }
+        }
+
+
+        [DelimitedFile(Delimiter = ",", HasHeader = false)]
+        class Record2
+        {
+
+            [DelimitedField(1)]
+            public char Type { get; set; }
+
+            [DelimitedField(2)]
+            public string Date { get; set; }
+
+            [DelimitedField(3)]
+            public string Description { get; set; }
+
+            public Record2() { Type = 'D'; }
+
+            bool Equals(Record2 other) { return Type == other.Type && string.Equals(Date, other.Date) && string.Equals(Description, other.Description); }
+
+            public override int GetHashCode()
+            {
+                unchecked
+                {
+                    var hashCode = Type.GetHashCode();
+                    hashCode = (hashCode * 397) ^ (Date != null ? Date.GetHashCode() : 0);
+                    hashCode = (hashCode * 397) ^ (Description != null ? Description.GetHashCode() : 0);
+                    return hashCode;
+                }
+            }
+
+            public override bool Equals(object obj)
+            {
+                if (ReferenceEquals(null, obj)) return false;
+                if (ReferenceEquals(this, obj)) return true;
+                return obj.GetType() == GetType() && Equals((Record2)obj);
+            }
+        }
+
+        sealed class Record1Layout : DelimitedLayout<Record1>
+        {
+            public Record1Layout()
+            {
+                HasHeader = false;
+                WithMember(x => x.Type, c => c.WithName("Type"))
+                    .WithMember(x => x.Description, c => c.WithName("Description"))
+                    .WithMember(x => x.Value, c => c.WithName("Value"));
+            }
+        }
+
+        sealed class Record2Layout : DelimitedLayout<Record2>
+        {
+            public Record2Layout()
+            {
+                WithMember(x => x.Type, c => c.WithName("Type"))
+                    .WithMember(x => x.Date, c => c.WithName("Date"))
+                    .WithMember(x => x.Description, c => c.WithName("Description"));
+            }
+        }
+
+        public DelimitedMultiEngineTests()
+        {
+
+            var factory = new DelimitedFileEngineFactory();
+            var types = new System.Collections.Generic.List<Type>()
+                {
+                    typeof(Record1),
+                    typeof(Record2)
+                };
+
+            engine = factory.GetEngine(types.AsEnumerable<Type>(),
+                                                    s =>
+                                                    {
+                                                        if (String.IsNullOrEmpty(s) || s.Length < 1) return null;
+
+                                                        switch (s[0])
+                                                        {
+                                                            case 'S':
+                                                                return typeof(Record1);
+                                                            case 'D':
+                                                                return typeof(Record2);
+                                                            default:
+                                                                return null;
+                                                        }
+                                                    }
+            );
+        }
+
+        [Fact]
+        public void EngineShouldReadMultipleRecordTypes()
+        {
+            using (var stream = GetStringStream(TestData))
+                engine.Read(stream);
+
+            var record1Results = engine.GetRecords<Record1>().ToList();
+            var record2Results = engine.GetRecords<Record2>().ToList();
+
+            record1Results.Should().HaveCount(1, "because it should read one 'S' record");
+            record2Results.Should().HaveCount(1, "because there is one 'D' record");
+
+            record1Results.First().Should().Be(new Record1 { Description = "Test Description", Value = 42 });
+            record2Results.First().Should().Be(new Record2 { Description = "Another Description", Date = "20150323" });
+        }
+
+        static Stream GetStringStream(string s)
+        {
+            var memoryStream = new MemoryStream();
+            var writer = new StreamWriter(memoryStream);
+            writer.Write(s);
+            writer.Flush();
+            memoryStream.Position = 0;
+            return memoryStream;
+        }
+    }
+}

--- a/src/FlatFile.Tests/FlatFile.Tests.csproj
+++ b/src/FlatFile.Tests/FlatFile.Tests.csproj
@@ -79,6 +79,7 @@
     <Compile Include="Delimited\DelimitedAttributeMappingIntegrationTests.cs" />
     <Compile Include="Delimited\DelimitedIntegrationTests.cs" />
     <Compile Include="Delimited\DelimitedLayoutTests.cs" />
+    <Compile Include="Delimited\DelimitedMultiEngineTests.cs" />
     <Compile Include="Delimited\DelimitedWithHeaderIntegrationTests.cs" />
     <Compile Include="FixedLength\FixedLayoutTests.cs" />
     <Compile Include="FixedLength\FixedLengthAttributeMappingIntegrationTests.cs" />


### PR DESCRIPTION
This request contains a possible implementation of the DelimitedFileMultiEngine, based on the FlatFileMultiEngine.  I would highlight one place where i think it diverges, which is in the implementation of DelimitedLayoutDescriptorProvider.GetDescriptor.  I attempted to follow the base class implementation used in FlatFile but couldn't get it to work and resorted to reflection to deal with this.  This is inconsistent and to be honest I'm not quite sure I'm happy with it, but I was on the clock.  Please advise if you see this as an issue.

I have implemented a test for this, similar to the FlatFileMultiEngine test, which did pass for me.

We are now using this in a production setting and would like to obtain FlatFile via a NuGet package rather than our own build.