### PR TITLE
Added feature which allow you to register a StringNormalizer function…

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,34 @@ public class LayoutFactory
 
         return layout;
     }
+
+    // you can also register a StringNormalizer function to convert input into the FixedLengthLineBuilder
+    // to a string compatible with the specifications for your target File. 
+    //
+    // Note that the StringNormalizer function is only used when creating/building files. Not when reading/parsing files.
+    //
+    // example:
+    public IFixedLayout<TestObject> GetLayout()
+    {
+        IFixedLayout<TestObject> layout = new FixedLayout<TestObject>()
+            .WithMember(o => o.Description, set => set
+                .WithLength(25)
+                .WithRightPadding(' ')
+                .WithStringNormalizer((input) => {
+                     // the normalization to FormD splits accented letters in accents+letters,
+                     // the rest aftet that removes those accents (and other non-spacing characters) from the ouput
+                     // So unicode L'été becomes L'ete
+                     return new string(
+                        input.Normalize(System.Text.NormalizationForm.FormD)
+                             .ToCharArray()
+                             .Where(c => CharUnicodeInfo.GetUnicodeCategory(c) != UnicodeCategory.NonSpacingMark)
+                             .ToArray());
+                }))
+
+        return layout;
+    }
+
+
 ```
 
 #### Attribute mapping

--- a/src/FlatFile.FixedLength.Attributes/FixedLengthFieldAttribute.cs
+++ b/src/FlatFile.FixedLength.Attributes/FixedLengthFieldAttribute.cs
@@ -18,6 +18,8 @@
 
         public bool TruncateIfExceedFieldLength { get; set; }
 
+        public Func<string, string> StringNormalizer { get; set; }
+
         public FixedLengthFieldAttribute(int index, int length, bool truncateIfExceed = false)
             : base(index)
         {

--- a/src/FlatFile.FixedLength/FixedFieldSettings.cs
+++ b/src/FlatFile.FixedLength/FixedFieldSettings.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace FlatFile.FixedLength
 {
     using System.Reflection;
@@ -9,7 +11,7 @@ namespace FlatFile.FixedLength
         bool PadLeft { get; }
         char PaddingChar { get; }
         bool TruncateIfExceedFieldLength { get; }
-
+        Func<string, string> StringNormalizer { get; }
     }
 
     public interface IFixedFieldSettingsContainer : IFixedFieldSettings, IFieldSettingsContainer
@@ -30,6 +32,7 @@ namespace FlatFile.FixedLength
             PaddingChar = settings.PaddingChar;
             TypeConverter = settings.TypeConverter;
             TruncateIfExceedFieldLength = settings.TruncateIfExceedFieldLength;
+            StringNormalizer = settings.StringNormalizer;
         }
 
         public FixedFieldSettings(PropertyInfo propertyInfo, IFixedFieldSettings settings)
@@ -42,5 +45,6 @@ namespace FlatFile.FixedLength
         public bool PadLeft { get; set; }
         public char PaddingChar { get; set; }
         public bool TruncateIfExceedFieldLength { get; set; }
+        public Func<string, string> StringNormalizer { get; set; }
     }
 }

--- a/src/FlatFile.FixedLength/IFixedFieldSettingsConstructor.cs
+++ b/src/FlatFile.FixedLength/IFixedFieldSettingsConstructor.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace FlatFile.FixedLength
 {
     using FlatFile.Core;
@@ -16,5 +18,7 @@ namespace FlatFile.FixedLength
         IFixedFieldSettingsConstructor WithRightPadding(char paddingChar);
 
         IFixedFieldSettingsConstructor TruncateFieldContentIfExceedLength();
+
+        IFixedFieldSettingsConstructor WithStringNormalizer(Func<string, string> stringNormalizer);
     }
 }

--- a/src/FlatFile.FixedLength/Implementation/FixedFieldSettingsConstructor.cs
+++ b/src/FlatFile.FixedLength/Implementation/FixedFieldSettingsConstructor.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace FlatFile.FixedLength.Implementation
 {
     using System.Reflection;
@@ -14,6 +16,12 @@ namespace FlatFile.FixedLength.Implementation
         public IFixedFieldSettingsConstructor TruncateFieldContentIfExceedLength()
         {
             TruncateIfExceedFieldLength = true;
+            return this;
+        }
+
+        public IFixedFieldSettingsConstructor WithStringNormalizer(Func<string, string> stringNormalizer)
+        {
+            StringNormalizer = stringNormalizer;
             return this;
         }
 

--- a/src/FlatFile.FixedLength/Implementation/FixedLengthLineBuilder.cs
+++ b/src/FlatFile.FixedLength/Implementation/FixedLengthLineBuilder.cs
@@ -22,6 +22,11 @@ namespace FlatFile.FixedLength.Implementation
 
         protected override string TransformFieldValue(IFixedFieldSettingsContainer field, string lineValue)
         {
+            if (field.StringNormalizer != null)
+            {
+                lineValue = field.StringNormalizer(lineValue);
+            }
+
             if (lineValue.Length >= field.Length)
             {
                 return field.TruncateIfExceedFieldLength ? lineValue.Substring(0, field.Length) : lineValue;


### PR DESCRIPTION
… in FixedLayout builder.

Hi there, I needed this badly to generate correct files for usage on a C proprietary OS only supporting ASCII encoding. Simply converting the bytes to ASCII encoding would mean loosing characters like 'é' because they would be converted into '?'. To handle these chars I needed a way to normalize the string input.

I hope you accept my PR and a new build can be pushed to Nuget asap. 

Thank you in advance,
Frank
 