### PR TITLE
overloaded Read method created to allow users to pass in as

### DIFF
--- a/src/FlatFile.FixedLength/Implementation/FixedLengthFileMultiEngine.cs
+++ b/src/FlatFile.FixedLength/Implementation/FixedLengthFileMultiEngine.cs
@@ -138,6 +138,27 @@ namespace FlatFile.FixedLength.Implementation
         public void Read(Stream stream)
         {
             var reader = new StreamReader(stream);
+            ReadInternal(reader);
+        }
+
+        /// <summary>
+        /// Reads the specified streamReader.
+        /// </summary>
+        /// <param name="reader">The stream reader configured as the user wants.</param>
+        /// <exception cref="ParseLineException">Impossible to parse line</exception>
+        public void Read(StreamReader reader)
+        {
+            ReadInternal(reader);
+        }
+
+        /// <summary>
+        /// Internal method (private) to read from streamreader instead of stream
+        /// This way the client code have a way to specify encoding.
+        /// </summary>
+        /// <param name="reader">The stream reader to read.</param>
+        /// <exception cref="ParseLineException">Impossible to parse line</exception>
+        private void ReadInternal(StreamReader reader)
+        {
             string line;
             var lineNumber = 0;
 


### PR DESCRIPTION
parameter one stream reader configured to use encoding as user wants.

```
const string enderecoArquivoBDI = @"G:\shared\bdi0713\BDIN";

        public void Read()
        {
            //
            var factory = new FixedLengthFileEngineFactory();
            using (var stream = new FileInfo(enderecoArquivoBDI).Open(FileMode.Open, FileAccess.Read, FileShare.Read))
            using (var streamReader = new StreamReader(stream, Encoding.ASCII)) // I can now specify which encoding to use it
            {
                // If using attribute mapping, pass an array of record types
                // rather than layout instances
                var layouts = new ILayoutDescriptor<IFixedFieldSettingsContainer>[]
                {
                    new BDIHeaderLayout()
                    ,new BDIIndiceLayout()
                    ,new BDINegociosPapelLayout()
                    ,new BDITrailerLayout()
                    ,new BDIMaioresOscilacoesVistaLayout()
                    ,new BDIMaioresOscilacoesIBOVLayout()
                    ,new BDIMaisNegociadasMercadoVistaLayout()
                    ,new BDIMaisNegociadasMercadoLayout()
                    ,new BDIResumoDiarioIOPVLayout()

                };

                var flatFile = factory.GetEngine(layouts,
                    line =>
                    {
                        // For each line, return the proper record type.
                        // The mapping for this line will be loaded based on that type.
                        // In this simple example, the first character determines the
                        // record type.
                        if (String.IsNullOrEmpty(line) || line.Length < 1) return null;
                        switch (line.Substring(0, 2))
                        {
                            case "00":
                                return typeof(BDIHeader);
                            case "01":
                                return typeof(BDIIndice);
                            case "02":
                                return typeof(BDINegociosPapel);
                            case "04":
                                return typeof(BDIMaiorOscilacaoVista);
                            case "05":
                                return typeof(BDIMaiorOscilacaoAcoesIBOV);
                            case "06":
                                return typeof(BDIMaisNegociadasMercadoVista);
                            case "07":
                                return typeof(BDIMaisNegociadasMercado);
                            case "08":
                                return typeof(BDIResumoDiarioIOPV);
                            case "99":
                                return typeof(BDITrailer);
                        }
                        return null;
                    });

                
                flatFile.Read(streamReader)

                var header = flatFile.GetRecords<BDIHeader>().FirstOrDefault();
                var indices = flatFile.GetRecords<BDIIndice>().ToList();
                var negocios = flatFile.GetRecords<BDINegociosPapel>().ToList();
                var oscilaVista = flatFile.GetRecords<BDIMaiorOscilacaoVista>().ToList();
                var oscilaIbov = flatFile.GetRecords<BDIMaiorOscilacaoAcoesIBOV>().ToList();
                var maisNegociadasVista = flatFile.GetRecords<BDIMaisNegociadasMercadoVista>().ToList();
                var maisNegociadasMerca = flatFile.GetRecords<BDIMaisNegociadasMercado>().ToList();
                var IOPV = flatFile.GetRecords<BDIResumoDiarioIOPV>().ToList();
                var trailer = flatFile.GetRecords<BDITrailer>().FirstOrDefault();
            }
        }
```