### PR TITLE
Fixed bug with ragged right files

### DIFF
--- a/src/FlatFile.FixedLength/Implementation/FixedLengthLineParser.cs
+++ b/src/FlatFile.FixedLength/Implementation/FixedLengthLineParser.cs
@@ -31,7 +31,7 @@ namespace FlatFile.FixedLength.Implementation
         {
             if (linePosition + field.Length > line.Length)
             {
-                if ((linePosition + field.Length) - line.Length != field.Length)
+                if ((linePosition + field.Length) - line.Length != field.Length && linePosition <= line.Length)
                 {
                     return line.Substring(linePosition);
                 }


### PR DESCRIPTION
This is just a small fix for a problem I encountered processing data dump files that were ragged right. These files were in a ragged right format where trailing fields were missing from some lines if no further fields contained data. I have learned this could have been caused if the data dumps were from a Cobol data formatted file (http://tech.wakayos.com/?p=293).

If the length of a line in a file falls short of providing a value for each field (ragged right file), the linePosition can end up equal to the length of the line. This doesn't cause a problem if this is the last field, but does pose a problem if there are additional fields to be checked.

On getting the value for the next field the linePosition ends up after the end of the line and throws an exception. The change makes sure that the linePosition is either at or below the end of the line length before trying to start the Substring function. This forces either the NullValue to be returned, or the exception defined a few lines below to be thrown.