### PR TITLE
Support customization of master-detail record handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,3 +157,5 @@ $RECYCLE.BIN/
 assets/FlatFile.Core.Compiled.nuspec
 assets/FlatFile.Delimited.Compiled.nuspec
 assets/FlatFile.FixedLength.Compiled.nuspec
+
+.vs/

--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,6 @@
 The MIT License (MIT)
 
+Copyright (c) 2018 Matt Hamilton
 Copyright (c) 2014 Pavel Nosovich
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 - 
-  version: 0.2.{build}
+  version: 0.3.{build}
 
   environment:
     BuildEnvironment: appveyor

--- a/src/FlatFile.Benchmark/Converters/CsvHelperTypeConverterForCustomType.cs
+++ b/src/FlatFile.Benchmark/Converters/CsvHelperTypeConverterForCustomType.cs
@@ -14,12 +14,12 @@
 
         public string ConvertToString(CsvHelperTypeConversion.TypeConverterOptions options, object value)
         {
-            return converter.ConvertToString(value);
+            return converter.ConvertToString(value, null);
         }
 
         public object ConvertFromString(CsvHelperTypeConversion.TypeConverterOptions options, string text)
         {
-            return converter.ConvertFromString(text);
+            return converter.ConvertFromString(text, null);
         }
 
         public bool CanConvertFrom(Type type)

--- a/src/FlatFile.Benchmark/Converters/FlatFileTypeConverterForCustomType.cs
+++ b/src/FlatFile.Benchmark/Converters/FlatFileTypeConverterForCustomType.cs
@@ -1,6 +1,7 @@
 ﻿namespace FlatFile.Benchmark.Converters
 {
     using System;
+    using System.Reflection;
     using FlatFile.Benchmark.Entities;
     using FlatFile.Core;
 
@@ -16,13 +17,13 @@
             return type == typeof (CustomType);
         }
 
-        public string ConvertToString(object source)
+        public string ConvertToString(object source, PropertyInfo sourceProperty)
         {
             var obj = (CustomType)source;
             return string.Format("{0}|{1}|{2}", obj.First, obj.Second, obj.Third);
         }
 
-        public object ConvertFromString(string source)
+        public object ConvertFromString(string source, PropertyInfo targetProperty)
         {
             var values = source.Split('|');
 

--- a/src/FlatFile.Core/Base/FlatFileEngine.cs
+++ b/src/FlatFile.Core/Base/FlatFileEngine.cs
@@ -24,7 +24,7 @@ namespace FlatFile.Core.Base
         /// Gets the line builder.
         /// </summary>
         /// <value>The line builder.</value>
-        protected abstract ILineBulder LineBuilder { get; }
+        protected abstract ILineBuilder LineBuilder { get; }
 
         /// <summary>
         /// Gets the line parser.

--- a/src/FlatFile.Core/Base/FlatFileEngine.cs
+++ b/src/FlatFile.Core/Base/FlatFileEngine.cs
@@ -57,6 +57,18 @@ namespace FlatFile.Core.Base
         public virtual IEnumerable<TEntity> Read<TEntity>(Stream stream) where TEntity : class, new()
         {
             var reader = new StreamReader(stream);
+            return Read<TEntity>(reader);
+        }
+
+        /// <summary>
+        /// Reads the specified text reader.
+        /// </summary>
+        /// <typeparam name="TEntity">The type of the t entity.</typeparam>
+        /// <param name="reader">The reader.</param>
+        /// <returns>IEnumerable&lt;TEntity&gt;.</returns>
+        /// <exception cref="ParseLineException">Impossible to parse line</exception>
+        public virtual IEnumerable<TEntity> Read<TEntity>(TextReader reader) where TEntity : class, new()
+        {
             string line;
             int lineNumber = 0;
 
@@ -68,7 +80,7 @@ namespace FlatFile.Core.Base
             while ((line = reader.ReadLine()) != null)
             {
                 if (string.IsNullOrEmpty(line) || string.IsNullOrEmpty(line.Trim())) continue;
-                
+
                 bool ignoreEntry = false;
                 var entry = new TEntity();
                 try
@@ -104,7 +116,7 @@ namespace FlatFile.Core.Base
         /// Processes the header.
         /// </summary>
         /// <param name="reader">The reader.</param>
-        protected virtual void ProcessHeader(StreamReader reader)
+        protected virtual void ProcessHeader(TextReader reader)
         {
             reader.ReadLine();
         }
@@ -147,7 +159,17 @@ namespace FlatFile.Core.Base
         public virtual void Write<TEntity>(Stream stream, IEnumerable<TEntity> entries) where TEntity : class, new()
         {
             TextWriter writer = new StreamWriter(stream);
+            Write(writer, entries);
+        }
 
+        /// <summary>
+        /// Writes to the specified text writer.
+        /// </summary>
+        /// <typeparam name="TEntity">The type of the t entity.</typeparam>
+        /// <param name="stream">The text writer.</param>
+        /// <param name="entries">The entries.</param>
+        public void Write<TEntity>(TextWriter writer, IEnumerable<TEntity> entries) where TEntity : class, new()
+        {
             this.WriteHeader(writer);
 
             int lineNumber = 0;

--- a/src/FlatFile.Core/Base/FlatFileEngine.cs
+++ b/src/FlatFile.Core/Base/FlatFileEngine.cs
@@ -18,7 +18,7 @@ namespace FlatFile.Core.Base
         /// <summary>
         /// The handle entry read error func
         /// </summary>
-        private readonly Func<string, Exception, bool> _handleEntryReadError;
+        private readonly Func<FlatFileErrorContext, bool> _handleEntryReadError;
 
         /// <summary>
         /// Gets the line builder.
@@ -42,7 +42,7 @@ namespace FlatFile.Core.Base
         /// Initializes a new instance of the <see cref="FlatFileEngine{TFieldSettings, TLayoutDescriptor}"/> class.
         /// </summary>
         /// <param name="handleEntryReadError">The handle entry read error.</param>
-        protected FlatFileEngine(Func<string, Exception, bool> handleEntryReadError = null)
+        protected FlatFileEngine(Func<FlatFileErrorContext, bool> handleEntryReadError = null)
         {
             _handleEntryReadError = handleEntryReadError;
         }
@@ -85,7 +85,7 @@ namespace FlatFile.Core.Base
                         throw;
                     }
 
-                    if (!_handleEntryReadError(line, ex))
+                    if (!_handleEntryReadError(new FlatFileErrorContext(line, lineNumber, ex)))
                     {
                         throw;
                     }

--- a/src/FlatFile.Core/Base/FlatFileErrorContext.cs
+++ b/src/FlatFile.Core/Base/FlatFileErrorContext.cs
@@ -7,6 +7,10 @@
     /// </summary>
     public struct FlatFileErrorContext
     {
+        private readonly string line;
+        private readonly int lineNumber;
+        private readonly Exception exception;
+
         /// <summary>
         /// Initializes a new instance of <see cref="FlatFileErrorContext"/>.
         /// </summary>
@@ -15,24 +19,33 @@
         /// <param name="exception">The error that occurred.</param>
         public FlatFileErrorContext(string line, int lineNumber, Exception exception)
         {
-            Line = line;
-            LineNumber = lineNumber;
-            Exception = exception;
+            this.line = line;
+            this.lineNumber = lineNumber;
+            this.exception = exception;
         }
 
         /// <summary>
         /// The content of the line on which the error occurred.
         /// </summary>
-        public string Line { get; private set; }
+        public string Line
+        {
+            get { return line; }
+        }
 
         /// <summary>
         /// The line numer at which the error occurred.
         /// </summary>
-        public int LineNumber { get; private set; }
+        public int LineNumber
+        {
+            get { return lineNumber; }
+        }
 
         /// <summary>
         /// The error that occurred.
         /// </summary>
-        public Exception Exception { get; private set; }
+        public Exception Exception
+        {
+            get { return exception; }
+        }
     }
 }

--- a/src/FlatFile.Core/Base/FlatFileErrorContext.cs
+++ b/src/FlatFile.Core/Base/FlatFileErrorContext.cs
@@ -1,0 +1,38 @@
+﻿namespace FlatFile.Core.Base
+{
+    using System;
+
+    /// <summary>
+    /// Provides information about a file parsing error.
+    /// </summary>
+    public struct FlatFileErrorContext
+    {
+        /// <summary>
+        /// Initializes a new instance of <see cref="FlatFileErrorContext"/>.
+        /// </summary>
+        /// <param name="line">The content of the line on which the error occurred.</param>
+        /// <param name="lineNumber">The line numer at which the error occurred.</param>
+        /// <param name="exception">The error that occurred.</param>
+        public FlatFileErrorContext(string line, int lineNumber, Exception exception)
+        {
+            Line = line;
+            LineNumber = lineNumber;
+            Exception = exception;
+        }
+
+        /// <summary>
+        /// The content of the line on which the error occurred.
+        /// </summary>
+        public string Line { get; }
+
+        /// <summary>
+        /// The line numer at which the error occurred.
+        /// </summary>
+        public int LineNumber { get; }
+
+        /// <summary>
+        /// The error that occurred.
+        /// </summary>
+        public Exception Exception { get; }
+    }
+}

--- a/src/FlatFile.Core/Base/FlatFileErrorContext.cs
+++ b/src/FlatFile.Core/Base/FlatFileErrorContext.cs
@@ -23,16 +23,16 @@
         /// <summary>
         /// The content of the line on which the error occurred.
         /// </summary>
-        public string Line { get; }
+        public string Line { get; private set; }
 
         /// <summary>
         /// The line numer at which the error occurred.
         /// </summary>
-        public int LineNumber { get; }
+        public int LineNumber { get; private set; }
 
         /// <summary>
         /// The error that occurred.
         /// </summary>
-        public Exception Exception { get; }
+        public Exception Exception { get; private set; }
     }
 }

--- a/src/FlatFile.Core/Base/LineBuilderBase.cs
+++ b/src/FlatFile.Core/Base/LineBuilderBase.cs
@@ -21,7 +21,7 @@ namespace FlatFile.Core.Base
         protected virtual string GetStringValueFromField(TFieldSettings field, object fieldValue)
         {
             string lineValue = fieldValue != null
-                ? fieldValue.ToString()
+                ? ConvertToString(field, fieldValue)
                 : field.NullValue ?? string.Empty;
 
             lineValue = TransformFieldValue(field, lineValue);
@@ -32,6 +32,15 @@ namespace FlatFile.Core.Base
         protected virtual string TransformFieldValue(TFieldSettings field, string lineValue)
         {
             return lineValue;
+        }
+
+        private static string ConvertToString(TFieldSettings field, object fieldValue)
+        {
+            var converter = field.TypeConverter;
+            if (converter != null && converter.CanConvertTo(typeof(string)) && converter.CanConvertFrom(field.PropertyInfo.PropertyType))
+                return field.TypeConverter.ConvertToString(fieldValue, field.PropertyInfo);
+
+            return fieldValue.ToString();
         }
     }
 }

--- a/src/FlatFile.Core/Base/LineBuilderBase.cs
+++ b/src/FlatFile.Core/Base/LineBuilderBase.cs
@@ -1,12 +1,12 @@
 namespace FlatFile.Core.Base
 {
-    public abstract class LineBulderBase<TLayoutDescriptor, TFieldSettings> : ILineBulder
+    public abstract class LineBuilderBase<TLayoutDescriptor, TFieldSettings> : ILineBuilder
         where TLayoutDescriptor : ILayoutDescriptor<TFieldSettings>
         where TFieldSettings : IFieldSettingsContainer 
     {
         private readonly TLayoutDescriptor _descriptor;
 
-        protected LineBulderBase(TLayoutDescriptor descriptor)
+        protected LineBuilderBase(TLayoutDescriptor descriptor)
         {
             this._descriptor = descriptor;
         }

--- a/src/FlatFile.Core/Base/LineParserBase.cs
+++ b/src/FlatFile.Core/Base/LineParserBase.cs
@@ -1,6 +1,7 @@
 namespace FlatFile.Core.Base
 {
     using System;
+    using System.Reflection;
     using FlatFile.Core.Extensions;
 
     public abstract class LineParserBase<TLayoutDescriptor, TFieldSettings> : ILineParser
@@ -39,7 +40,7 @@ namespace FlatFile.Core.Base
 
             object obj;
             
-            if (!fieldSettings.TypeConverter.ConvertFromStringTo(memberValue, type, out obj))
+            if (!fieldSettings.TypeConverter.ConvertFromStringTo(memberValue, type, fieldSettings.PropertyInfo, out obj))
             {
                 obj = memberValue.Convert(type);
             }
@@ -56,11 +57,11 @@ namespace FlatFile.Core.Base
     public static class TypeConverterExtensions
     {
 
-        public static bool ConvertFromStringTo(this ITypeConverter converter, string source, Type targetType, out object obj)
+        public static bool ConvertFromStringTo(this ITypeConverter converter, string source, Type targetType, PropertyInfo targetProperty, out object obj)
         {
             if (converter != null && converter.CanConvertFrom(typeof(string)) && converter.CanConvertTo(targetType))
             {
-                obj = converter.ConvertFromString(source);
+                obj = converter.ConvertFromString(source, targetProperty);
                 return true;
             }
 

--- a/src/FlatFile.Core/Base/MasterDetailTrackerBase.cs
+++ b/src/FlatFile.Core/Base/MasterDetailTrackerBase.cs
@@ -1,12 +1,12 @@
 ﻿using System;
 
-namespace FlatFile.FixedLength.Implementation
+namespace FlatFile.Core.Base
 {
     /// <summary>
     /// Uses records that implement <see cref="IMasterRecord"/> and <see cref="IDetailRecord"/> to handle
     /// master-detail record relationships.
     /// </summary>
-    public class MasterDetailTracker : IMasterDetailTracker
+    public class MasterDetailTrackerBase : IMasterDetailTracker
     {
         /// <summary>
         /// Determines whether a record is a master record.
@@ -25,24 +25,13 @@ namespace FlatFile.FixedLength.Implementation
         /// </summary>
         object lastMasterRecord;
 
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="MasterDetailTracker"/> class.
-        /// </summary>
-        public MasterDetailTracker()
-            : this(entry => entry is IMasterRecord,
-                   entry => entry is IDetailRecord,
-                   (master, detail) => ((IMasterRecord)master).DetailRecords.Add((IDetailRecord)detail))
-        {
-        }
-
         /// <summary>
         /// Initializes a new instance of the <see cref="MasterDetailTracker"/> class.
         /// </summary>
         /// <param name="checkIsMasterRecord">Determines whether a record is a master record.</param>
         /// <param name="checkIsDetailRecord">Determines whether a record is a detail record.</param>
         /// <param name="handleDetailRecord">Handles confirmed detail records.</param>
-        public MasterDetailTracker(
+        public MasterDetailTrackerBase(
             Func<object, bool> checkIsMasterRecord,
             Func<object, bool> checkIsDetailRecord,
             Action<object, object> handleDetailRecord)

--- a/src/FlatFile.Core/Base/TypeConverterBase.cs
+++ b/src/FlatFile.Core/Base/TypeConverterBase.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Reflection;
+
+namespace FlatFile.Core.Base
+{
+    /// <summary>
+    /// A generic base class for converting between strings and a given type.
+    /// </summary>
+    /// <typeparam name="TValue">The type to convert to and from a string.</typeparam>
+    public abstract class TypeConverterBase<TValue> : ITypeConverter
+    {
+        public virtual bool CanConvertFrom(Type type)
+        {
+            return type == typeof(string) || type == typeof(TValue);
+        }
+
+        public virtual bool CanConvertTo(Type type)
+        {
+            return type == typeof(string) || type == typeof(TValue);
+        }
+
+        public object ConvertFromString(string source, PropertyInfo targetProperty)
+        {
+            return ConvertFrom(source, targetProperty);
+        }
+
+        protected abstract TValue ConvertFrom(string source, PropertyInfo targetProperty);
+
+        public string ConvertToString(object source, PropertyInfo sourceProperty)
+        {
+            return ConvertTo((TValue)source, sourceProperty);
+        }
+
+        protected abstract string ConvertTo(TValue source, PropertyInfo sourceProperty);
+    }
+}

--- a/src/FlatFile.Core/DelegatingTypeConverter.cs
+++ b/src/FlatFile.Core/DelegatingTypeConverter.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Reflection;
+
+namespace FlatFile.Core
+{
+    /// <summary>
+    /// An implementation of <see cref="ITypeConverter"/> that uses delegates for conversion.
+    /// </summary>
+    class DelegatingTypeConverter<TProperty> : ITypeConverter
+    {
+        internal Func<string, TProperty> ConversionFromString { get; set; }
+
+        internal Func<TProperty, string> ConversionToString { get; set; }
+
+        public bool CanConvertFrom(Type type)
+        {
+            return (type == typeof(string) && ConversionFromString != null) ||
+                   (type == typeof(TProperty) && ConversionToString != null);
+        }
+
+        public bool CanConvertTo(Type type)
+        {
+            return (type == typeof(string) && ConversionToString != null) ||
+                   (type == typeof(TProperty) && ConversionFromString != null);
+        }
+
+        public object ConvertFromString(string source, PropertyInfo targetProperty)
+        {
+            return ConversionFromString(source);
+        }
+
+        public string ConvertToString(object source, PropertyInfo sourceProperty)
+        {
+            return ConversionToString((TProperty)source);
+        }
+    }
+}

--- a/src/FlatFile.Core/FlatFile.Core.csproj
+++ b/src/FlatFile.Core/FlatFile.Core.csproj
@@ -98,6 +98,7 @@
     <Compile Include="Base\FieldsContainer.cs" />
     <Compile Include="Base\FieldSettingsBase.cs" />
     <Compile Include="Base\FlatFileEngine.cs" />
+    <Compile Include="Base\FlatFileErrorContext.cs" />
     <Compile Include="Base\LayoutBase.cs" />
     <Compile Include="Base\LayoutDescriptorBase.cs" />
     <Compile Include="Base\LineBulderBase.cs" />

--- a/src/FlatFile.Core/FlatFile.Core.csproj
+++ b/src/FlatFile.Core/FlatFile.Core.csproj
@@ -95,6 +95,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Base\MasterDetailTrackerBase.cs" />
     <Compile Include="Base\FieldsContainer.cs" />
     <Compile Include="Base\FieldSettingsBase.cs" />
     <Compile Include="Base\FlatFileEngine.cs" />
@@ -120,6 +121,7 @@
     <Compile Include="ILineBulder.cs" />
     <Compile Include="ILineParser.cs" />
     <Compile Include="ILineParserFactory.cs" />
+    <Compile Include="IMasterDetailTracker.cs" />
     <Compile Include="ITypeConverter.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/src/FlatFile.Core/FlatFile.Core.csproj
+++ b/src/FlatFile.Core/FlatFile.Core.csproj
@@ -100,7 +100,7 @@
     <Compile Include="Base\FlatFileEngine.cs" />
     <Compile Include="Base\LayoutBase.cs" />
     <Compile Include="Base\LayoutDescriptorBase.cs" />
-    <Compile Include="Base\LineBulderBase.cs" />
+    <Compile Include="Base\LineBuilderBase.cs" />
     <Compile Include="Base\LineParserBase.cs" />
     <Compile Include="Exceptions\ParseLineException.cs" />
     <Compile Include="Extensions\ExpressionExtensions.cs" />
@@ -117,7 +117,7 @@
     <Compile Include="ILayout.cs" />
     <Compile Include="ILayoutDescriptor.cs" />
     <Compile Include="ILineBuilderFactory.cs" />
-    <Compile Include="ILineBulder.cs" />
+    <Compile Include="ILineBuilder.cs" />
     <Compile Include="ILineParser.cs" />
     <Compile Include="ILineParserFactory.cs" />
     <Compile Include="ITypeConverter.cs" />

--- a/src/FlatFile.Core/FlatFile.Core.csproj
+++ b/src/FlatFile.Core/FlatFile.Core.csproj
@@ -102,6 +102,8 @@
     <Compile Include="Base\LayoutDescriptorBase.cs" />
     <Compile Include="Base\LineBuilderBase.cs" />
     <Compile Include="Base\LineParserBase.cs" />
+    <Compile Include="Base\TypeConverterBase.cs" />
+    <Compile Include="DelegatingTypeConverter.cs" />
     <Compile Include="Exceptions\ParseLineException.cs" />
     <Compile Include="Extensions\ExpressionExtensions.cs" />
     <Compile Include="Extensions\FieldsSettingsExtensions.cs" />

--- a/src/FlatFile.Core/IFieldSettingsConstructor.cs
+++ b/src/FlatFile.Core/IFieldSettingsConstructor.cs
@@ -1,11 +1,14 @@
 ﻿namespace FlatFile.Core
 {
     using FlatFile.Core.Base;
+    using System;
 
     public interface IFieldSettingsConstructor<out TConstructor> : IFieldSettingsContainer
         where TConstructor : IFieldSettingsConstructor<TConstructor>
     {
         TConstructor AllowNull(string nullValue);
         TConstructor WithTypeConverter<TConverter>() where TConverter : ITypeConverter;
+        TConstructor WithConversionFromString<TProperty>(Func<string, TProperty> conversion);
+        TConstructor WithConversionToString<TProperty>(Func<TProperty, string> conversion);
     }
 }

--- a/src/FlatFile.Core/IFlatFileEngine.cs
+++ b/src/FlatFile.Core/IFlatFileEngine.cs
@@ -17,11 +17,27 @@
         IEnumerable<TEntity> Read<TEntity>(Stream stream) where TEntity : class, new();
 
         /// <summary>
+        /// Reads from the specified text reader.
+        /// </summary>
+        /// <typeparam name="TEntity">The type of the t entity.</typeparam>
+        /// <param name="stream">The text reader.</param>
+        /// <returns>IEnumerable&lt;TEntity&gt;.</returns>
+        IEnumerable<TEntity> Read<TEntity>(TextReader reader) where TEntity : class, new();
+
+        /// <summary>
         /// Writes to the specified stream.
         /// </summary>
         /// <typeparam name="TEntity">The type of the t entity.</typeparam>
         /// <param name="stream">The stream.</param>
         /// <param name="entries">The entries.</param>
         void Write<TEntity>(Stream stream, IEnumerable<TEntity> entries) where TEntity : class, new();
+
+        /// <summary>
+        /// Writes to the specified text writer.
+        /// </summary>
+        /// <typeparam name="TEntity">The type of the t entity.</typeparam>
+        /// <param name="writer">The text writer.</param>
+        /// <param name="entries">The entries.</param>
+        void Write<TEntity>(TextWriter writer, IEnumerable<TEntity> entries) where TEntity : class, new();
     }
 }

--- a/src/FlatFile.Core/IFlatFileMultiEngine.cs
+++ b/src/FlatFile.Core/IFlatFileMultiEngine.cs
@@ -13,12 +13,20 @@ namespace FlatFile.Core
         /// </summary>
         /// <param name="stream">The stream.</param>
         void Read(Stream stream);
+
+        /// <summary>
+        /// Reads the specified text reader.
+        /// </summary>
+        /// <param name="stream">The text reader.</param>
+        void Read(TextReader reader);
+
         /// <summary>
         /// Gets any records of type <typeparamref name="T"/> read by <see cref="Read"/>.
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <returns>IEnumerable&lt;T&gt;.</returns>
         IEnumerable<T> GetRecords<T>() where T : class, new();
+
         /// <summary>
         /// Gets or sets a value indicating whether this instance has a file header.
         /// </summary>

--- a/src/FlatFile.Core/ILineBuilder.cs
+++ b/src/FlatFile.Core/ILineBuilder.cs
@@ -1,6 +1,6 @@
 namespace FlatFile.Core
 {
-    public interface ILineBulder
+    public interface ILineBuilder
     {
         string BuildLine<T>(T entry);
     }

--- a/src/FlatFile.Core/ILineBuilderFactory.cs
+++ b/src/FlatFile.Core/ILineBuilderFactory.cs
@@ -5,7 +5,7 @@ namespace FlatFile.Core
     public interface ILineBuilderFactory<out TBuilder, in TLayout, TFieldSettings>
         where TFieldSettings : IFieldSettings   
         where TLayout : ILayoutDescriptor<TFieldSettings>
-        where TBuilder : ILineBulder
+        where TBuilder : ILineBuilder
     {
         TBuilder GetBuilder(TLayout layout);
     }

--- a/src/FlatFile.Core/IMasterDetailTracker.cs
+++ b/src/FlatFile.Core/IMasterDetailTracker.cs
@@ -1,4 +1,4 @@
-﻿namespace FlatFile.FixedLength
+﻿namespace FlatFile.Core
 {
     /// <summary>
     /// Determines how master-detail record relationships are handled.

--- a/src/FlatFile.Core/ITypeConverter.cs
+++ b/src/FlatFile.Core/ITypeConverter.cs
@@ -1,6 +1,7 @@
 ﻿namespace FlatFile.Core
 {
     using System;
+    using System.Reflection;
 
     public interface ITypeConverter
     {
@@ -8,8 +9,8 @@
 
         bool CanConvertTo(Type type);
 
-        string ConvertToString(object source);
+        string ConvertToString(object source, PropertyInfo sourceProperty);
 
-        object ConvertFromString(string source);
+        object ConvertFromString(string source, PropertyInfo targetProperty);
     }
 }

--- a/src/FlatFile.Delimited.Attributes/FlatFileEngineFactoryExtensions.cs
+++ b/src/FlatFile.Delimited.Attributes/FlatFileEngineFactoryExtensions.cs
@@ -37,16 +37,18 @@ namespace FlatFile.Delimited.Attributes
         /// <param name="recordTypes">The record types.</param>
         /// <param name="typeSelectorFunc">The type selector function.</param>
         /// <param name="handleEntryReadError">The handle entry read error.</param>
+        /// <param name="masterDetailTracker">Determines how master-detail record relationships are handled.</param>
         /// <returns>IFlatFileMultiEngine.</returns>
         public static IFlatFileMultiEngine GetEngine(
             this DelimitedFileEngineFactory engineFactory,
             IEnumerable<Type> recordTypes,
             Func<string, Type> typeSelectorFunc,
-            Func<string, Exception, bool> handleEntryReadError = null)
+            Func<string, Exception, bool> handleEntryReadError = null,
+            IMasterDetailTracker masterDetailTracker = null)
         {
             var descriptorProvider = new DelimitedLayoutDescriptorProvider();
             var descriptors = recordTypes.Select(type => descriptorProvider.GetDescriptor(type)).ToList();
-            return engineFactory.GetEngine(descriptors, typeSelectorFunc, handleEntryReadError);
+            return engineFactory.GetEngine(descriptors, typeSelectorFunc, handleEntryReadError, masterDetailTracker);
         }
     }
 }

--- a/src/FlatFile.Delimited/FlatFile.Delimited.csproj
+++ b/src/FlatFile.Delimited/FlatFile.Delimited.csproj
@@ -113,6 +113,7 @@
     <Compile Include="Implementation\DelimitedLineBuilderFactory.cs" />
     <Compile Include="Implementation\DelimitedLineParser.cs" />
     <Compile Include="Implementation\DelimitedLineParserFactory.cs" />
+    <Compile Include="Implementation\DelimitedMasterDetailTracker.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/FlatFile.Delimited/IDelimitedLineBuilder.cs
+++ b/src/FlatFile.Delimited/IDelimitedLineBuilder.cs
@@ -2,7 +2,7 @@
 {
     using FlatFile.Core;
 
-    public interface IDelimitedLineBuilder : ILineBulder
+    public interface IDelimitedLineBuilder : ILineBuilder
     {
     }
 }

--- a/src/FlatFile.Delimited/Implementation/DelimetedFileMultiEngine.cs
+++ b/src/FlatFile.Delimited/Implementation/DelimetedFileMultiEngine.cs
@@ -137,7 +137,16 @@ namespace FlatFile.Delimited.Implementation
         /// <exception cref="ParseLineException">Impossible to parse line</exception>
         public void Read(Stream stream)
         {
-            var reader = new StreamReader(stream);
+            Read(new StreamReader(stream));
+        }
+
+        /// <summary>
+        /// Reads the specified text reader.
+        /// </summary>
+        /// <param name="stream">The text reader.</param>
+        /// <exception cref="ParseLineException">Impossible to parse line</exception>
+        public void Read(TextReader reader)
+        {
             string line;
             var lineNumber = 0;
 

--- a/src/FlatFile.Delimited/Implementation/DelimetedFileMultiEngine.cs
+++ b/src/FlatFile.Delimited/Implementation/DelimetedFileMultiEngine.cs
@@ -18,7 +18,7 @@ namespace FlatFile.Delimited.Implementation
         /// <summary>
         /// The handle entry read error func
         /// </summary>
-        readonly Func<string, Exception, bool> handleEntryReadError;
+        readonly Func<FlatFileErrorContext, bool> handleEntryReadError;
         /// <summary>
         /// The layout descriptors for this engine
         /// </summary>
@@ -58,7 +58,7 @@ namespace FlatFile.Delimited.Implementation
             Func<string, Type> typeSelectorFunc,
             IDelimitedLineBuilderFactory lineBuilderFactory,
             IDelimitedLineParserFactory lineParserFactory,
-            Func<string, Exception, bool> handleEntryReadError = null)
+            Func<FlatFileErrorContext, bool> handleEntryReadError = null)
         {
             if (typeSelectorFunc == null) throw new ArgumentNullException("typeSelectorFunc");
             this.layoutDescriptors = layoutDescriptors.ToList();
@@ -170,7 +170,7 @@ namespace FlatFile.Delimited.Implementation
                         throw;
                     }
 
-                    if (!handleEntryReadError(line, ex))
+                    if (!handleEntryReadError(new FlatFileErrorContext(line, lineNumber, ex)))
                     {
                         throw;
                     }

--- a/src/FlatFile.Delimited/Implementation/DelimetedFileMultiEngine.cs
+++ b/src/FlatFile.Delimited/Implementation/DelimetedFileMultiEngine.cs
@@ -40,9 +40,9 @@ namespace FlatFile.Delimited.Implementation
         /// </summary>
         readonly Dictionary<Type, ArrayList> results;
         /// <summary>
-        /// The last record parsed that implements <see cref="IMasterRecord"/>
+        /// Determines how master-detail record relationships are handled.
         /// </summary>
-        IMasterRecord lastMasterRecord;
+        readonly IMasterDetailTracker masterDetailTracker;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DelimetedFileMultiEngine"/> class.
@@ -58,6 +58,7 @@ namespace FlatFile.Delimited.Implementation
             Func<string, Type> typeSelectorFunc,
             IDelimitedLineBuilderFactory lineBuilderFactory,
             IDelimitedLineParserFactory lineParserFactory,
+            IMasterDetailTracker masterDetailTracker,
             Func<string, Exception, bool> handleEntryReadError = null)
         {
             if (typeSelectorFunc == null) throw new ArgumentNullException("typeSelectorFunc");
@@ -70,6 +71,7 @@ namespace FlatFile.Delimited.Implementation
             this.typeSelectorFunc = typeSelectorFunc;
             this.lineBuilderFactory = lineBuilderFactory;
             this.lineParserFactory = lineParserFactory;
+            this.masterDetailTracker = masterDetailTracker;
             this.handleEntryReadError = handleEntryReadError;
         }
 
@@ -181,48 +183,12 @@ namespace FlatFile.Delimited.Implementation
                 if (ignoreEntry) continue;
 
                 bool isDetailRecord;
-                HandleMasterDetail(entry, out isDetailRecord);
+                masterDetailTracker.HandleMasterDetail(entry, out isDetailRecord);
 
                 if (isDetailRecord) continue;
 
                 results[type].Add(entry);
             }
         }
-
-
-        /// <summary>
-        /// Handles any master/detail relationships for this <paramref name="entry"/>.
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="entry">The entry.</param>
-        /// <param name="isDetailRecord">if set to <c>true</c> [is detail record] and should not be added to the results dictionary.</param>
-        void HandleMasterDetail<T>(T entry, out bool isDetailRecord)
-        {
-            isDetailRecord = false;
-
-            var masterRecord = entry as IMasterRecord;
-            if (masterRecord != null)
-            {
-                // Found new master record
-                lastMasterRecord = masterRecord;
-                return;
-            }
-
-            // Record is standalone or unassociated detail record
-            if (lastMasterRecord == null) return;
-
-            var detailRecord = entry as IDetailRecord;
-            if (detailRecord == null)
-            {
-                // Record is standalone, reset master
-                lastMasterRecord = null;
-                return;
-            }
-
-            // Add detail record and indicate that it should not be added to the results dictionary
-            lastMasterRecord.DetailRecords.Add(detailRecord);
-            isDetailRecord = true;
-        }
-        
     }
 }

--- a/src/FlatFile.Delimited/Implementation/DelimetedFileMultiEngine.cs
+++ b/src/FlatFile.Delimited/Implementation/DelimetedFileMultiEngine.cs
@@ -79,7 +79,7 @@ namespace FlatFile.Delimited.Implementation
         /// <value>The line builder.</value>
         /// <remarks>The <see cref="DelimitedFileMultiEngine"/> does not contain just a single line builder.</remarks>
         /// <exception cref="System.NotImplementedException"></exception>
-        protected override ILineBulder LineBuilder { get { throw new NotImplementedException(); } }
+        protected override ILineBuilder LineBuilder { get { throw new NotImplementedException(); } }
 
         /// <summary>
         /// Gets the line parser.

--- a/src/FlatFile.Delimited/Implementation/DelimetedFileMultiEngine.cs
+++ b/src/FlatFile.Delimited/Implementation/DelimetedFileMultiEngine.cs
@@ -141,7 +141,7 @@ namespace FlatFile.Delimited.Implementation
         }
 
         /// <summary>
-        /// Reads the specified text reader.
+        /// Reads from the specified text reader.
         /// </summary>
         /// <param name="stream">The text reader.</param>
         /// <exception cref="ParseLineException">Impossible to parse line</exception>

--- a/src/FlatFile.Delimited/Implementation/DelimitedFieldSettingsConstructor.cs
+++ b/src/FlatFile.Delimited/Implementation/DelimitedFieldSettingsConstructor.cs
@@ -1,5 +1,6 @@
 ﻿namespace FlatFile.Delimited.Implementation
 {
+    using System;
     using System.Reflection;
     using FlatFile.Core;
     using FlatFile.Core.Extensions;
@@ -22,6 +23,32 @@
         public IDelimitedFieldSettingsConstructor WithTypeConverter<TConverter>() where TConverter : ITypeConverter
         {
             this.TypeConverter = ReflectionHelper.CreateInstance<TConverter>(true);
+            return this;
+        }
+
+        public IDelimitedFieldSettingsConstructor WithConversionFromString<TProperty>(Func<string, TProperty> conversion)
+        {
+            if (TypeConverter == null)
+                TypeConverter = new DelegatingTypeConverter<TProperty>();
+
+            if (TypeConverter is DelegatingTypeConverter<TProperty>)
+                ((DelegatingTypeConverter<TProperty>)TypeConverter).ConversionFromString = conversion;
+            else
+                throw new InvalidOperationException("A type converter has already been explicitly set.");
+
+            return this;
+        }
+
+        public IDelimitedFieldSettingsConstructor WithConversionToString<TProperty>(Func<TProperty, string> conversion)
+        {
+            if (TypeConverter == null)
+                TypeConverter = new DelegatingTypeConverter<TProperty>();
+
+            if (TypeConverter is DelegatingTypeConverter<TProperty>)
+                ((DelegatingTypeConverter<TProperty>)TypeConverter).ConversionToString = conversion;
+            else
+                throw new InvalidOperationException("A type converter has already been explicitly set.");
+
             return this;
         }
 

--- a/src/FlatFile.Delimited/Implementation/DelimitedFileEngine.cs
+++ b/src/FlatFile.Delimited/Implementation/DelimitedFileEngine.cs
@@ -38,7 +38,7 @@ namespace FlatFile.Delimited.Implementation
             IDelimitedLayoutDescriptor layoutDescriptor,
             IDelimitedLineBuilderFactory builderFactory,
             IDelimitedLineParserFactory parserFactory, 
-            Func<string, Exception, bool> handleEntryReadError = null)
+            Func<FlatFileErrorContext, bool> handleEntryReadError = null)
             : base(handleEntryReadError)
         {
             _builderFactory = builderFactory;

--- a/src/FlatFile.Delimited/Implementation/DelimitedFileEngine.cs
+++ b/src/FlatFile.Delimited/Implementation/DelimitedFileEngine.cs
@@ -50,7 +50,7 @@ namespace FlatFile.Delimited.Implementation
         /// Gets the line builder.
         /// </summary>
         /// <value>The line builder.</value>
-        protected override ILineBulder LineBuilder
+        protected override ILineBuilder LineBuilder
         {
             get { return _builderFactory.GetBuilder(LayoutDescriptor); }
         }

--- a/src/FlatFile.Delimited/Implementation/DelimitedFileEngineFactory.cs
+++ b/src/FlatFile.Delimited/Implementation/DelimitedFileEngineFactory.cs
@@ -51,10 +51,25 @@ namespace FlatFile.Delimited.Implementation
                 descriptor,
                 new DelimitedLineBuilderFactory(),
                 new DelimitedLineParserFactory(),
-                handleEntryReadError);
+                ctx => handleEntryReadError(ctx.Line, ctx.Exception));
         }
 
-
+        /// <summary>
+        /// Gets the <see cref="IFlatFileEngine" />.
+        /// </summary>
+        /// <param name="descriptor">The descriptor.</param>
+        /// <param name="handleEntryReadError">The handle entry read error func.</param>
+        /// <returns>IFlatFileEngine.</returns>
+        public IFlatFileEngine GetEngine(
+            IDelimitedLayoutDescriptor descriptor,
+            Func<FlatFileErrorContext, bool> handleEntryReadError)
+        {
+            return new DelimitedFileEngine(
+                descriptor,
+                new DelimitedLineBuilderFactory(),
+                new DelimitedLineParserFactory(),
+                handleEntryReadError);
+        }
 
         /// <summary>
         /// Gets the <see cref="IFlatFileMultiEngine"/>.
@@ -67,6 +82,26 @@ namespace FlatFile.Delimited.Implementation
             IEnumerable<IDelimitedLayoutDescriptor> layoutDescriptors,
             Func<string, Type> typeSelectorFunc,
             Func<string, Exception, bool> handleEntryReadError = null)
+        {
+            return new DelimitedFileMultiEngine(
+                layoutDescriptors,
+                typeSelectorFunc,
+                new DelimitedLineBuilderFactory(),
+                lineParserFactory,
+                ctx => handleEntryReadError(ctx.Line, ctx.Exception));
+        }
+
+        /// <summary>
+        /// Gets the <see cref="IFlatFileMultiEngine"/>.
+        /// </summary>
+        /// <param name="layoutDescriptors">The layout descriptors.</param>
+        /// <param name="typeSelectorFunc">The type selector function.</param>
+        /// <param name="handleEntryReadError">The handle entry read error func.</param>
+        /// <returns>IFlatFileMultiEngine.</returns>
+        public IFlatFileMultiEngine GetEngine(
+            IEnumerable<IDelimitedLayoutDescriptor> layoutDescriptors,
+            Func<string, Type> typeSelectorFunc,
+            Func<FlatFileErrorContext, bool> handleEntryReadError)
         {
             return new DelimitedFileMultiEngine(
                 layoutDescriptors,

--- a/src/FlatFile.Delimited/Implementation/DelimitedFileEngineFactory.cs
+++ b/src/FlatFile.Delimited/Implementation/DelimitedFileEngineFactory.cs
@@ -100,17 +100,20 @@ namespace FlatFile.Delimited.Implementation
         /// <param name="layoutDescriptors">The layout descriptors.</param>
         /// <param name="typeSelectorFunc">The type selector function.</param>
         /// <param name="handleEntryReadError">The handle entry read error func.</param>
+        /// <param name="masterDetailTracker">Determines how master-detail record relationships are handled.</param>
         /// <returns>IFlatFileMultiEngine.</returns>
         public IFlatFileMultiEngine GetEngine(
             IEnumerable<IDelimitedLayoutDescriptor> layoutDescriptors,
             Func<string, Type> typeSelectorFunc,
-            Func<FlatFileErrorContext, bool> handleEntryReadError)
+            Func<FlatFileErrorContext, bool> handleEntryReadError,
+            IMasterDetailTracker masterDetailTracker = null)
         {
             return new DelimitedFileMultiEngine(
                 layoutDescriptors,
                 typeSelectorFunc,
                 new DelimitedLineBuilderFactory(),
                 lineParserFactory,
+                masterDetailTracker ?? new DelimitedMasterDetailTracker(),
                 handleEntryReadError);
         }
     }

--- a/src/FlatFile.Delimited/Implementation/DelimitedFileEngineFactory.cs
+++ b/src/FlatFile.Delimited/Implementation/DelimitedFileEngineFactory.cs
@@ -62,17 +62,20 @@ namespace FlatFile.Delimited.Implementation
         /// <param name="layoutDescriptors">The layout descriptors.</param>
         /// <param name="typeSelectorFunc">The type selector function.</param>
         /// <param name="handleEntryReadError">The handle entry read error func.</param>
+        /// <param name="masterDetailTracker">Determines how master-detail record relationships are handled.</param>
         /// <returns>IFlatFileMultiEngine.</returns>
         public IFlatFileMultiEngine GetEngine(
             IEnumerable<IDelimitedLayoutDescriptor> layoutDescriptors,
             Func<string, Type> typeSelectorFunc,
-            Func<string, Exception, bool> handleEntryReadError = null)
+            Func<string, Exception, bool> handleEntryReadError = null,
+            IMasterDetailTracker masterDetailTracker = null)
         {
             return new DelimitedFileMultiEngine(
                 layoutDescriptors,
                 typeSelectorFunc,
                 new DelimitedLineBuilderFactory(),
                 lineParserFactory,
+                masterDetailTracker ?? new DelimitedMasterDetailTracker(),
                 handleEntryReadError);
         }
     }

--- a/src/FlatFile.Delimited/Implementation/DelimitedLineBuilder.cs
+++ b/src/FlatFile.Delimited/Implementation/DelimitedLineBuilder.cs
@@ -4,7 +4,7 @@
     using FlatFile.Core.Base;
 
     public class DelimitedLineBuilder :
-        LineBulderBase<IDelimitedLayoutDescriptor, IDelimitedFieldSettingsContainer>, 
+        LineBuilderBase<IDelimitedLayoutDescriptor, IDelimitedFieldSettingsContainer>, 
         IDelimitedLineBuilder
     {
         public DelimitedLineBuilder(IDelimitedLayoutDescriptor descriptor)

--- a/src/FlatFile.Delimited/Implementation/DelimitedMasterDetailTracker.cs
+++ b/src/FlatFile.Delimited/Implementation/DelimitedMasterDetailTracker.cs
@@ -1,0 +1,21 @@
+﻿using FlatFile.Core.Base;
+
+namespace FlatFile.Delimited.Implementation
+{
+    /// <summary>
+    /// Uses records that implement <see cref="IMasterRecord"/> and <see cref="IDetailRecord"/> to handle
+    /// master-detail record relationships.
+    /// </summary>
+    public class DelimitedMasterDetailTracker : MasterDetailTrackerBase
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MasterDetailTracker"/> class.
+        /// </summary>
+        public DelimitedMasterDetailTracker()
+            : base(entry => entry is IMasterRecord,
+                   entry => entry is IDetailRecord,
+                   (master, detail) => ((IMasterRecord)master).DetailRecords.Add((IDetailRecord)detail))
+        {
+        }
+    }
+}

--- a/src/FlatFile.FixedLength/FlatFile.FixedLength.csproj
+++ b/src/FlatFile.FixedLength/FlatFile.FixedLength.csproj
@@ -95,7 +95,6 @@
   <ItemGroup>
     <Compile Include="FixedFieldSettings.cs" />
     <Compile Include="IDetailRecord.cs" />
-    <Compile Include="IMasterDetailTracker.cs" />
     <Compile Include="IMasterRecord.cs" />
     <Compile Include="Implementation\FixedLengthFileMultiEngine.cs" />
     <Compile Include="IFixedFieldSettingsConstructor.cs" />
@@ -113,7 +112,7 @@
     <Compile Include="Implementation\FixedLengthLineBuilderFactory.cs" />
     <Compile Include="Implementation\FixedLengthLineParser.cs" />
     <Compile Include="Implementation\FixedLengthLineParserFactory.cs" />
-    <Compile Include="Implementation\MasterDetailTracker.cs" />
+    <Compile Include="Implementation\FixedLengthMasterDetailTracker.cs" />
     <Compile Include="Padding.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/src/FlatFile.FixedLength/FlatFile.FixedLength.csproj
+++ b/src/FlatFile.FixedLength/FlatFile.FixedLength.csproj
@@ -95,6 +95,7 @@
   <ItemGroup>
     <Compile Include="FixedFieldSettings.cs" />
     <Compile Include="IDetailRecord.cs" />
+    <Compile Include="IMasterDetailTracker.cs" />
     <Compile Include="IMasterRecord.cs" />
     <Compile Include="Implementation\FixedLengthFileMultiEngine.cs" />
     <Compile Include="IFixedFieldSettingsConstructor.cs" />
@@ -112,6 +113,7 @@
     <Compile Include="Implementation\FixedLengthLineBuilderFactory.cs" />
     <Compile Include="Implementation\FixedLengthLineParser.cs" />
     <Compile Include="Implementation\FixedLengthLineParserFactory.cs" />
+    <Compile Include="Implementation\MasterDetailTracker.cs" />
     <Compile Include="Padding.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/src/FlatFile.FixedLength/IFixedLengthLineBuilder.cs
+++ b/src/FlatFile.FixedLength/IFixedLengthLineBuilder.cs
@@ -2,7 +2,7 @@ namespace FlatFile.FixedLength
 {
     using FlatFile.Core;
 
-    public interface IFixedLengthLineBuilder : ILineBulder
+    public interface IFixedLengthLineBuilder : ILineBuilder
     {
     }
 }

--- a/src/FlatFile.FixedLength/IMasterDetailTracker.cs
+++ b/src/FlatFile.FixedLength/IMasterDetailTracker.cs
@@ -1,0 +1,10 @@
+﻿namespace FlatFile.FixedLength
+{
+    /// <summary>
+    /// Determines how master-detail record relationships are handled.
+    /// </summary>
+    public interface IMasterDetailTracker
+    {
+        void HandleMasterDetail(object entry, out bool isDetailRecord);
+    }
+}

--- a/src/FlatFile.FixedLength/Implementation/FixedFieldSettingsConstructor.cs
+++ b/src/FlatFile.FixedLength/Implementation/FixedFieldSettingsConstructor.cs
@@ -57,5 +57,31 @@ namespace FlatFile.FixedLength.Implementation
             this.TypeConverter = ReflectionHelper.CreateInstance<TConverter>(true);
             return this;
         }
+
+        public IFixedFieldSettingsConstructor WithConversionFromString<TProperty>(Func<string, TProperty> conversion)
+        {
+            if (TypeConverter == null)
+                TypeConverter = new DelegatingTypeConverter<TProperty>();
+
+            if (TypeConverter is DelegatingTypeConverter<TProperty>)
+                ((DelegatingTypeConverter<TProperty>)TypeConverter).ConversionFromString = conversion;
+            else
+                throw new InvalidOperationException("A type converter has already been explicitly set.");
+
+            return this;
+        }
+
+        public IFixedFieldSettingsConstructor WithConversionToString<TProperty>(Func<TProperty, string> conversion)
+        {
+            if (TypeConverter == null)
+                TypeConverter = new DelegatingTypeConverter<TProperty>();
+
+            if (TypeConverter is DelegatingTypeConverter<TProperty>)
+                ((DelegatingTypeConverter<TProperty>)TypeConverter).ConversionToString = conversion;
+            else
+                throw new InvalidOperationException("A type converter has already been explicitly set.");
+
+            return this;
+        }
     }
 }

--- a/src/FlatFile.FixedLength/Implementation/FixedLengthFileEngine.cs
+++ b/src/FlatFile.FixedLength/Implementation/FixedLengthFileEngine.cs
@@ -33,7 +33,7 @@ namespace FlatFile.FixedLength.Implementation
             ILayoutDescriptor<IFixedFieldSettingsContainer> layoutDescriptor,
             IFixedLengthLineBuilderFactory lineBuilderFactory,
             IFixedLengthLineParserFactory lineParserFactory,
-            Func<string, Exception, bool> handleEntryReadError = null) : base(handleEntryReadError)
+            Func<FlatFileErrorContext, bool> handleEntryReadError = null) : base(handleEntryReadError)
         {
             this.lineBuilderFactory = lineBuilderFactory;
             this.lineParserFactory = lineParserFactory;

--- a/src/FlatFile.FixedLength/Implementation/FixedLengthFileEngine.cs
+++ b/src/FlatFile.FixedLength/Implementation/FixedLengthFileEngine.cs
@@ -44,7 +44,7 @@ namespace FlatFile.FixedLength.Implementation
         /// Gets the line builder.
         /// </summary>
         /// <value>The line builder.</value>
-        protected override ILineBulder LineBuilder
+        protected override ILineBuilder LineBuilder
         {
             get { return lineBuilderFactory.GetBuilder(LayoutDescriptor); }
         }

--- a/src/FlatFile.FixedLength/Implementation/FixedLengthFileEngineFactory.cs
+++ b/src/FlatFile.FixedLength/Implementation/FixedLengthFileEngineFactory.cs
@@ -71,7 +71,7 @@ namespace FlatFile.FixedLength.Implementation
                 typeSelectorFunc,
                 new FixedLengthLineBuilderFactory(),
                 lineParserFactory,
-                masterDetailTracker ?? new MasterDetailTracker(),
+                masterDetailTracker ?? new FixedLengthMasterDetailTracker(),
                 handleEntryReadError);
         }
     }

--- a/src/FlatFile.FixedLength/Implementation/FixedLengthFileEngineFactory.cs
+++ b/src/FlatFile.FixedLength/Implementation/FixedLengthFileEngineFactory.cs
@@ -58,17 +58,20 @@ namespace FlatFile.FixedLength.Implementation
         /// <param name="layoutDescriptors">The layout descriptors.</param>
         /// <param name="typeSelectorFunc">The type selector function.</param>
         /// <param name="handleEntryReadError">The handle entry read error func.</param>
+        /// <param name="masterDetailTracker">Determines how master-detail record relationships are handled.</param>
         /// <returns>IFlatFileMultiEngine.</returns>
         public IFlatFileMultiEngine GetEngine(
             IEnumerable<ILayoutDescriptor<IFixedFieldSettingsContainer>> layoutDescriptors,
             Func<string, int, Type> typeSelectorFunc,
-            Func<string, Exception, bool> handleEntryReadError = null)
+            Func<string, Exception, bool> handleEntryReadError = null,
+            IMasterDetailTracker masterDetailTracker = null)
         {
             return new FixedLengthFileMultiEngine(
                 layoutDescriptors,
                 typeSelectorFunc,
                 new FixedLengthLineBuilderFactory(),
                 lineParserFactory,
+                masterDetailTracker ?? new MasterDetailTracker(),
                 handleEntryReadError);
         }
     }

--- a/src/FlatFile.FixedLength/Implementation/FixedLengthFileEngineFactory.cs
+++ b/src/FlatFile.FixedLength/Implementation/FixedLengthFileEngineFactory.cs
@@ -98,17 +98,20 @@ namespace FlatFile.FixedLength.Implementation
         /// <param name="layoutDescriptors">The layout descriptors.</param>
         /// <param name="typeSelectorFunc">The type selector function.</param>
         /// <param name="handleEntryReadError">The handle entry read error func.</param>
+        /// <param name="masterDetailTracker">Determines how master-detail record relationships are handled.</param>
         /// <returns>IFlatFileMultiEngine.</returns>
         public IFlatFileMultiEngine GetEngine(
             IEnumerable<ILayoutDescriptor<IFixedFieldSettingsContainer>> layoutDescriptors,
             Func<string, int, Type> typeSelectorFunc,
-            Func<FlatFileErrorContext, bool> handleEntryReadError)
+            Func<FlatFileErrorContext, bool> handleEntryReadError,
+            IMasterDetailTracker masterDetailTracker = null)
         {
             return new FixedLengthFileMultiEngine(
                 layoutDescriptors,
                 typeSelectorFunc,
                 new FixedLengthLineBuilderFactory(),
                 lineParserFactory,
+                masterDetailTracker ?? new FixedLengthMasterDetailTracker(),
                 handleEntryReadError);
         }
     }

--- a/src/FlatFile.FixedLength/Implementation/FixedLengthFileEngineFactory.cs
+++ b/src/FlatFile.FixedLength/Implementation/FixedLengthFileEngineFactory.cs
@@ -48,7 +48,24 @@ namespace FlatFile.FixedLength.Implementation
             return new FixedLengthFileEngine(
                 descriptor, 
                 new FixedLengthLineBuilderFactory(),
-                lineParserFactory, 
+                lineParserFactory,
+                ctx => handleEntryReadError(ctx.Line, ctx.Exception));
+        }
+
+        /// <summary>
+        /// Gets the <see cref="IFlatFileEngine" />.
+        /// </summary>
+        /// <param name="descriptor">The descriptor.</param>
+        /// <param name="handleEntryReadError">The handle entry read error func.</param>
+        /// <returns>IFlatFileEngine.</returns>
+        public IFlatFileEngine GetEngine(
+            ILayoutDescriptor<IFixedFieldSettingsContainer> descriptor,
+            Func<FlatFileErrorContext, bool> handleEntryReadError)
+        {
+            return new FixedLengthFileEngine(
+                descriptor,
+                new FixedLengthLineBuilderFactory(),
+                lineParserFactory,
                 handleEntryReadError);
         }
 
@@ -63,6 +80,26 @@ namespace FlatFile.FixedLength.Implementation
             IEnumerable<ILayoutDescriptor<IFixedFieldSettingsContainer>> layoutDescriptors,
             Func<string, int, Type> typeSelectorFunc,
             Func<string, Exception, bool> handleEntryReadError = null)
+        {
+            return new FixedLengthFileMultiEngine(
+                layoutDescriptors,
+                typeSelectorFunc,
+                new FixedLengthLineBuilderFactory(),
+                lineParserFactory,
+                ctx => handleEntryReadError(ctx.Line, ctx.Exception));
+        }
+
+        /// <summary>
+        /// Gets the <see cref="IFlatFileMultiEngine"/>.
+        /// </summary>
+        /// <param name="layoutDescriptors">The layout descriptors.</param>
+        /// <param name="typeSelectorFunc">The type selector function.</param>
+        /// <param name="handleEntryReadError">The handle entry read error func.</param>
+        /// <returns>IFlatFileMultiEngine.</returns>
+        public IFlatFileMultiEngine GetEngine(
+            IEnumerable<ILayoutDescriptor<IFixedFieldSettingsContainer>> layoutDescriptors,
+            Func<string, int, Type> typeSelectorFunc,
+            Func<FlatFileErrorContext, bool> handleEntryReadError)
         {
             return new FixedLengthFileMultiEngine(
                 layoutDescriptors,

--- a/src/FlatFile.FixedLength/Implementation/FixedLengthFileMultiEngine.cs
+++ b/src/FlatFile.FixedLength/Implementation/FixedLengthFileMultiEngine.cs
@@ -79,7 +79,7 @@ namespace FlatFile.FixedLength.Implementation
         /// <value>The line builder.</value>
         /// <remarks>The <see cref="FixedLengthFileMultiEngine"/> does not contain just a single line builder.</remarks>
         /// <exception cref="System.NotImplementedException"></exception>
-        protected override ILineBulder LineBuilder { get { throw new NotImplementedException(); } }
+        protected override ILineBuilder LineBuilder { get { throw new NotImplementedException(); } }
 
         /// <summary>
         /// Gets the line parser.

--- a/src/FlatFile.FixedLength/Implementation/FixedLengthFileMultiEngine.cs
+++ b/src/FlatFile.FixedLength/Implementation/FixedLengthFileMultiEngine.cs
@@ -51,8 +51,8 @@ namespace FlatFile.FixedLength.Implementation
         /// <param name="typeSelectorFunc">The type selector function.</param>
         /// <param name="lineBuilderFactory">The line builder factory.</param>
         /// <param name="lineParserFactory">The line parser factory.</param>
-        /// <param name="handleEntryReadError">The handle entry read error.</param>
         /// <param name="masterDetailTracker">Determines how master-detail record relationships are handled.</param>
+        /// <param name="handleEntryReadError">The handle entry read error.</param>
         /// <exception cref="System.ArgumentNullException">typeSelectorFunc</exception>
         internal FixedLengthFileMultiEngine(
             IEnumerable<ILayoutDescriptor<IFixedFieldSettingsContainer>> layoutDescriptors,
@@ -60,7 +60,6 @@ namespace FlatFile.FixedLength.Implementation
             IFixedLengthLineBuilderFactory lineBuilderFactory,
             IFixedLengthLineParserFactory lineParserFactory,
             IMasterDetailTracker masterDetailTracker,
-            Func<string, Exception, bool> handleEntryReadError = null)
             Func<FlatFileErrorContext, bool> handleEntryReadError = null)
         {
             if (typeSelectorFunc == null) throw new ArgumentNullException("typeSelectorFunc");

--- a/src/FlatFile.FixedLength/Implementation/FixedLengthFileMultiEngine.cs
+++ b/src/FlatFile.FixedLength/Implementation/FixedLengthFileMultiEngine.cs
@@ -40,9 +40,9 @@ namespace FlatFile.FixedLength.Implementation
         /// </summary>
         readonly Dictionary<Type, ArrayList> results;
         /// <summary>
-        /// The last record parsed that implements <see cref="IMasterRecord"/>
+        /// Determines how master-detail record relationships are handled.
         /// </summary>
-        IMasterRecord lastMasterRecord;
+        readonly IMasterDetailTracker masterDetailTracker;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="FixedLengthFileMultiEngine"/> class.
@@ -52,12 +52,14 @@ namespace FlatFile.FixedLength.Implementation
         /// <param name="lineBuilderFactory">The line builder factory.</param>
         /// <param name="lineParserFactory">The line parser factory.</param>
         /// <param name="handleEntryReadError">The handle entry read error.</param>
+        /// <param name="masterDetailTracker">Determines how master-detail record relationships are handled.</param>
         /// <exception cref="System.ArgumentNullException">typeSelectorFunc</exception>
         internal FixedLengthFileMultiEngine(
             IEnumerable<ILayoutDescriptor<IFixedFieldSettingsContainer>> layoutDescriptors,
             Func<string, int, Type> typeSelectorFunc,
             IFixedLengthLineBuilderFactory lineBuilderFactory,
             IFixedLengthLineParserFactory lineParserFactory,
+            IMasterDetailTracker masterDetailTracker,
             Func<string, Exception, bool> handleEntryReadError = null)
         {
             if (typeSelectorFunc == null) throw new ArgumentNullException("typeSelectorFunc");
@@ -70,6 +72,7 @@ namespace FlatFile.FixedLength.Implementation
             this.typeSelectorFunc = typeSelectorFunc;
             this.lineBuilderFactory = lineBuilderFactory;
             this.lineParserFactory = lineParserFactory;
+            this.masterDetailTracker = masterDetailTracker;
             this.handleEntryReadError = handleEntryReadError;
         }
 
@@ -202,47 +205,12 @@ namespace FlatFile.FixedLength.Implementation
                 if (ignoreEntry) continue;
 
                 bool isDetailRecord;
-                HandleMasterDetail(entry, out isDetailRecord);
+                masterDetailTracker.HandleMasterDetail(entry, out isDetailRecord);
 
                 if (isDetailRecord) continue;
 
                 results[type].Add(entry);
             }
-        }
-
-
-        /// <summary>
-        /// Handles any master/detail relationships for this <paramref name="entry"/>.
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="entry">The entry.</param>
-        /// <param name="isDetailRecord">if set to <c>true</c> [is detail record] and should not be added to the results dictionary.</param>
-        void HandleMasterDetail<T>(T entry, out bool isDetailRecord)
-        {
-            isDetailRecord = false;
-
-            var masterRecord = entry as IMasterRecord;
-            if (masterRecord != null)
-            {
-                // Found new master record
-                lastMasterRecord = masterRecord;
-                return;
-            }
-
-            // Record is standalone or unassociated detail record
-            if (lastMasterRecord == null) return;
-
-            var detailRecord = entry as IDetailRecord;
-            if (detailRecord == null)
-            {
-                // Record is standalone, reset master
-                lastMasterRecord = null;
-                return;
-            }
-
-            // Add detail record and indicate that it should not be added to the results dictionary
-            lastMasterRecord.DetailRecords.Add(detailRecord);
-            isDetailRecord = true;
         }
     }
 }

--- a/src/FlatFile.FixedLength/Implementation/FixedLengthFileMultiEngine.cs
+++ b/src/FlatFile.FixedLength/Implementation/FixedLengthFileMultiEngine.cs
@@ -142,22 +142,22 @@ namespace FlatFile.FixedLength.Implementation
         }
 
         /// <summary>
-        /// Reads the specified streamReader.
+        /// Reads the specified text reader.
         /// </summary>
-        /// <param name="reader">The stream reader configured as the user wants.</param>
+        /// <param name="reader">The text reader configured as the user wants.</param>
         /// <exception cref="ParseLineException">Impossible to parse line</exception>
-        public void Read(StreamReader reader)
+        public void Read(TextReader reader)
         {
             ReadInternal(reader);
         }
 
         /// <summary>
-        /// Internal method (private) to read from streamreader instead of stream
+        /// Internal method (private) to read from a text reader instead of stream
         /// This way the client code have a way to specify encoding.
         /// </summary>
-        /// <param name="reader">The stream reader to read.</param>
+        /// <param name="reader">The text reader to read.</param>
         /// <exception cref="ParseLineException">Impossible to parse line</exception>
-        private void ReadInternal(StreamReader reader)
+        private void ReadInternal(TextReader reader)
         {
             string line;
             var lineNumber = 0;

--- a/src/FlatFile.FixedLength/Implementation/FixedLengthFileMultiEngine.cs
+++ b/src/FlatFile.FixedLength/Implementation/FixedLengthFileMultiEngine.cs
@@ -142,7 +142,7 @@ namespace FlatFile.FixedLength.Implementation
         }
 
         /// <summary>
-        /// Reads the specified text reader.
+        /// Reads from the specified text reader.
         /// </summary>
         /// <param name="reader">The text reader configured as the user wants.</param>
         /// <exception cref="ParseLineException">Impossible to parse line</exception>

--- a/src/FlatFile.FixedLength/Implementation/FixedLengthFileMultiEngine.cs
+++ b/src/FlatFile.FixedLength/Implementation/FixedLengthFileMultiEngine.cs
@@ -18,7 +18,7 @@ namespace FlatFile.FixedLength.Implementation
         /// <summary>
         /// The handle entry read error func
         /// </summary>
-        readonly Func<string, Exception, bool> handleEntryReadError;
+        readonly Func<FlatFileErrorContext, bool> handleEntryReadError;
         /// <summary>
         /// The layout descriptors for this engine
         /// </summary>
@@ -58,7 +58,7 @@ namespace FlatFile.FixedLength.Implementation
             Func<string, int, Type> typeSelectorFunc,
             IFixedLengthLineBuilderFactory lineBuilderFactory,
             IFixedLengthLineParserFactory lineParserFactory,
-            Func<string, Exception, bool> handleEntryReadError = null)
+            Func<FlatFileErrorContext, bool> handleEntryReadError = null)
         {
             if (typeSelectorFunc == null) throw new ArgumentNullException("typeSelectorFunc");
             this.layoutDescriptors = layoutDescriptors.ToList();
@@ -191,7 +191,7 @@ namespace FlatFile.FixedLength.Implementation
                         throw;
                     }
 
-                    if (!handleEntryReadError(line, ex))
+                    if (!handleEntryReadError(new FlatFileErrorContext(line, lineNumber, ex)))
                     {
                         throw;
                     }

--- a/src/FlatFile.FixedLength/Implementation/FixedLengthLineBuilder.cs
+++ b/src/FlatFile.FixedLength/Implementation/FixedLengthLineBuilder.cs
@@ -5,7 +5,7 @@ namespace FlatFile.FixedLength.Implementation
     using FlatFile.Core.Base;
 
     public class FixedLengthLineBuilder :
-        LineBulderBase<ILayoutDescriptor<IFixedFieldSettingsContainer>, IFixedFieldSettingsContainer>,
+        LineBuilderBase<ILayoutDescriptor<IFixedFieldSettingsContainer>, IFixedFieldSettingsContainer>,
         IFixedLengthLineBuilder
     {
         public FixedLengthLineBuilder(ILayoutDescriptor<IFixedFieldSettingsContainer> descriptor)

--- a/src/FlatFile.FixedLength/Implementation/FixedLengthMasterDetailTracker.cs
+++ b/src/FlatFile.FixedLength/Implementation/FixedLengthMasterDetailTracker.cs
@@ -1,0 +1,21 @@
+﻿using FlatFile.Core.Base;
+
+namespace FlatFile.FixedLength.Implementation
+{
+    /// <summary>
+    /// Uses records that implement <see cref="IMasterRecord"/> and <see cref="IDetailRecord"/> to handle
+    /// master-detail record relationships.
+    /// </summary>
+    public class FixedLengthMasterDetailTracker : MasterDetailTrackerBase
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FixedLengthMasterDetailTracker"/> class.
+        /// </summary>
+        public FixedLengthMasterDetailTracker()
+            : base(entry => entry is IMasterRecord,
+                   entry => entry is IDetailRecord,
+                   (master, detail) => ((IMasterRecord)master).DetailRecords.Add((IDetailRecord)detail))
+        {
+        }
+    }
+}

--- a/src/FlatFile.FixedLength/Implementation/MasterDetailTracker.cs
+++ b/src/FlatFile.FixedLength/Implementation/MasterDetailTracker.cs
@@ -1,0 +1,81 @@
+﻿using System;
+
+namespace FlatFile.FixedLength.Implementation
+{
+    /// <summary>
+    /// Uses records that implement <see cref="IMasterRecord"/> and <see cref="IDetailRecord"/> to handle
+    /// master-detail record relationships.
+    /// </summary>
+    public class MasterDetailTracker : IMasterDetailTracker
+    {
+        /// <summary>
+        /// Determines whether a record is a master record.
+        /// </summary>
+        readonly Func<object, bool> checkIsMasterRecord;
+        /// <summary>
+        /// Determines whether a record is a detail record.
+        /// </summary>
+        readonly Func<object, bool> checkIsDetailRecord;
+        /// <summary>
+        /// Handles confirmed detail records.
+        /// </summary>
+        readonly Action<object, object> handleDetailRecord;
+        /// <summary>
+        /// The last record parsed that implements <see cref="IMasterRecord"/>
+        /// </summary>
+        object lastMasterRecord;
+
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MasterDetailTracker"/> class.
+        /// </summary>
+        public MasterDetailTracker()
+            : this(entry => entry is IMasterRecord,
+                   entry => entry is IDetailRecord,
+                   (master, detail) => ((IMasterRecord)master).DetailRecords.Add((IDetailRecord)detail))
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MasterDetailTracker"/> class.
+        /// </summary>
+        /// <param name="checkIsMasterRecord">Determines whether a record is a master record.</param>
+        /// <param name="checkIsDetailRecord">Determines whether a record is a detail record.</param>
+        /// <param name="handleDetailRecord">Handles confirmed detail records.</param>
+        public MasterDetailTracker(
+            Func<object, bool> checkIsMasterRecord,
+            Func<object, bool> checkIsDetailRecord,
+            Action<object, object> handleDetailRecord)
+        {
+            this.checkIsMasterRecord = checkIsMasterRecord;
+            this.checkIsDetailRecord = checkIsDetailRecord;
+            this.handleDetailRecord = handleDetailRecord;
+        }
+
+        public void HandleMasterDetail(object entry, out bool isDetailRecord)
+        {
+            isDetailRecord = false;
+
+            if (checkIsMasterRecord(entry))
+            {
+                // Found new master record
+                lastMasterRecord = entry;
+                return;
+            }
+
+            // Record is standalone or unassociated detail record
+            if (lastMasterRecord == null) return;
+
+            if (!checkIsDetailRecord(entry))
+            {
+                // Record is standalone, reset master
+                lastMasterRecord = null;
+                return;
+            }
+
+            // Add detail record and indicate that it should not be added to the results dictionary
+            handleDetailRecord(lastMasterRecord, entry);
+            isDetailRecord = true;
+        }
+    }
+}

--- a/src/FlatFile.Tests/Delimited/DelimitedAttributeMappingIntegrationTests.cs
+++ b/src/FlatFile.Tests/Delimited/DelimitedAttributeMappingIntegrationTests.cs
@@ -36,7 +36,7 @@ namespace FlatFile.Tests.Delimited
 		{
 			// a converter to convert "A" to "foo"
 			var converter = A.Fake<ITypeConverter>();
-			A.CallTo(() => converter.ConvertFromString("A")).Returns("foo");
+			A.CallTo(() => converter.ConvertFromString("A", A<PropertyInfo>.Ignored)).Returns("foo");
 			A.CallTo(() => converter.CanConvertFrom(typeof(string))).Returns(true);
 			A.CallTo(() => converter.CanConvertTo(typeof(string))).Returns(true);
 

--- a/src/FlatFile.Tests/Delimited/DelimitedErrorHandlingTests.cs
+++ b/src/FlatFile.Tests/Delimited/DelimitedErrorHandlingTests.cs
@@ -31,9 +31,9 @@ S,Test Description,00044";
             A.CallTo(() => lineParserFactory.GetParser(A<IDelimitedLayoutDescriptor>.Ignored))
                 .Returns(new FakeLineParser());
                 
-                new DelimitedLineParserFactory(new Dictionary<Type, Type>
+            new DelimitedLineParserFactory(new Dictionary<Type, Type>
             {
-                [typeof(Record)] = typeof(FakeLineParser)
+                { typeof(Record), typeof(FakeLineParser) }
             });
         }
 

--- a/src/FlatFile.Tests/Delimited/DelimitedErrorHandlingTests.cs
+++ b/src/FlatFile.Tests/Delimited/DelimitedErrorHandlingTests.cs
@@ -1,0 +1,93 @@
+﻿using FakeItEasy;
+using FlatFile.Core.Base;
+using FlatFile.Delimited;
+using FlatFile.Delimited.Implementation;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Xunit;
+
+namespace FlatFile.Tests.Delimited
+{
+    public class DelimitedErrorHandlingTests
+    {
+        private IDelimitedLayoutDescriptor layout;
+        readonly IDelimitedLineParserFactory lineParserFactory;
+        readonly IList<FlatFileErrorContext> errorContexts = new List<FlatFileErrorContext>();
+
+        const string TestData = 
+@"S,Test Description,00042
+S,Test Description,00043
+S,Test Description,00044";
+
+        public DelimitedErrorHandlingTests()
+        {
+            layout = A.Fake<IDelimitedLayoutDescriptor>();
+            A.CallTo(() => layout.TargetType).Returns(typeof(Record));
+
+            lineParserFactory = A.Fake<IDelimitedLineParserFactory>();
+            A.CallTo(() => lineParserFactory.GetParser(A<IDelimitedLayoutDescriptor>.Ignored))
+                .Returns(new FakeLineParser());
+                
+                new DelimitedLineParserFactory(new Dictionary<Type, Type>
+            {
+                [typeof(Record)] = typeof(FakeLineParser)
+            });
+        }
+
+        [Fact]
+        public void ErrorContextShouldProvideAccurateInformation()
+        {
+            var engine = new DelimitedFileEngine(
+                layout,
+                A.Fake<IDelimitedLineBuilderFactory>(),
+                lineParserFactory,
+                HandleError);
+
+            using (var stream = new MemoryStream(Encoding.Default.GetBytes(TestData)))
+                engine.Read<Record>(stream).ToList();
+
+            Assert.Equal(3, errorContexts.Count);
+            Assert.Equal(new[] { 1, 2, 3 }, errorContexts.Select(ctx => ctx.LineNumber));
+            Assert.Equal(TestData.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries), errorContexts.Select(ctx => ctx.Line));
+            Assert.All(errorContexts, ctx => Assert.Equal("Parsing failed!", ctx.Exception.Message));
+        }
+
+        [Fact]
+        public void MultiEngineErrorContextShouldProvideAccurateInformation()
+        {
+            var engine = new DelimitedFileMultiEngine(
+                new[] { layout },
+                l => typeof(Record),
+                A.Fake<IDelimitedLineBuilderFactory>(),
+                lineParserFactory,
+                HandleError);
+
+            using (var stream = new MemoryStream(Encoding.Default.GetBytes(TestData)))
+                engine.Read(stream);
+
+            Assert.Equal(3, errorContexts.Count);
+            Assert.Equal(new[] { 1, 2, 3 }, errorContexts.Select(ctx => ctx.LineNumber));
+            Assert.Equal(TestData.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries), errorContexts.Select(ctx => ctx.Line));
+            Assert.All(errorContexts, ctx => Assert.Equal("Parsing failed!", ctx.Exception.Message));
+        }
+
+        private bool HandleError(FlatFileErrorContext context)
+        {
+            errorContexts.Add(context);
+            return true;
+        }
+
+        private class FakeLineParser : IDelimitedLineParser
+        {
+            public TEntity ParseLine<TEntity>(string line, TEntity entity) where TEntity : new()
+            {
+                throw new Exception("Parsing failed!");
+            }
+        }
+
+        private class Record { }
+    }
+}

--- a/src/FlatFile.Tests/Delimited/DelimitedErrorHandlingTests.cs
+++ b/src/FlatFile.Tests/Delimited/DelimitedErrorHandlingTests.cs
@@ -63,6 +63,7 @@ S,Test Description,00044";
                 l => typeof(Record),
                 A.Fake<IDelimitedLineBuilderFactory>(),
                 lineParserFactory,
+                new DelimitedMasterDetailTracker(),
                 HandleError);
 
             using (var stream = new MemoryStream(Encoding.Default.GetBytes(TestData)))

--- a/src/FlatFile.Tests/Delimited/DelimitedLineBuilderTests.cs
+++ b/src/FlatFile.Tests/Delimited/DelimitedLineBuilderTests.cs
@@ -1,0 +1,68 @@
+﻿namespace FlatFile.Tests.Delimited
+{
+    using FlatFile.Core.Base;
+    using FlatFile.Delimited;
+    using FlatFile.Delimited.Implementation;
+    using FlatFile.Tests.Base.Entities;
+    using FluentAssertions;
+    using System;
+    using System.Globalization;
+    using System.Reflection;
+    using Xunit;
+
+    public class DelimitedLineBuilderTests
+    {
+        private readonly DelimitedLineBuilder builder;
+        private readonly IDelimitedLayout<TestObject> layout;
+
+        public DelimitedLineBuilderTests()
+        {
+            layout = new DelimitedLayout<TestObject>().WithDelimiter(",");
+
+            builder = new DelimitedLineBuilder(layout);
+        }
+
+        [Fact]
+        public void BuilderShouldUseTypeConverter()
+        {
+            layout.WithMember(o => o.Id, set => set.WithTypeConverter<IdHexConverter>());
+
+            var entry = new TestObject
+            {
+                Id = 48879
+            };
+
+            var line = builder.BuildLine(entry);
+
+            line.Should().Be("BEEF");
+        }
+
+        [Fact]
+        public void BuilderShouldUseConversionFunction()
+        {
+            layout.WithMember(o => o.Id, set => set.WithConversionToString((int id) => id.ToString("X")));
+
+            var entry = new TestObject
+            {
+                Id = 48879
+            };
+
+            var line = builder.BuildLine(entry);
+
+            line.Should().Be("BEEF");
+        }
+
+        class IdHexConverter : TypeConverterBase<int>
+        {
+            protected override int ConvertFrom(string source, PropertyInfo targetProperty)
+            {
+                return Int32.Parse(source, NumberStyles.AllowHexSpecifier);
+            }
+
+            protected override string ConvertTo(int source, PropertyInfo sourceProperty)
+            {
+                return source.ToString("X");
+            }
+        }
+    }
+}

--- a/src/FlatFile.Tests/Delimited/DelimitedLineParserTests.cs
+++ b/src/FlatFile.Tests/Delimited/DelimitedLineParserTests.cs
@@ -1,0 +1,60 @@
+﻿namespace FlatFile.Tests.Delimited
+{
+    using FlatFile.Core.Base;
+    using FlatFile.Delimited;
+    using FlatFile.Delimited.Implementation;
+    using FlatFile.Tests.Base.Entities;
+    using FluentAssertions;
+    using System;
+    using System.Globalization;
+    using System.Reflection;
+    using Xunit;
+
+    public class DelimitedLineParserTests
+    {
+        private readonly DelimitedLineParser parser;
+        private readonly IDelimitedLayout<TestObject> layout;
+
+        public DelimitedLineParserTests()
+        {
+            layout = new DelimitedLayout<TestObject>().WithDelimiter(",");
+
+            parser = new DelimitedLineParser(layout);
+        }
+
+        [Fact]
+        public void ParserShouldUseTypeConverter()
+        {
+            layout.WithMember(o => o.Id, set => set.WithTypeConverter<IdHexConverter>());
+
+            var entry = new TestObject();
+            var parsedEntity = parser.ParseLine("BEEF", entry);
+
+            parsedEntity.Id.Should().Be(48879);
+        }
+
+        [Fact]
+        public void ParserShouldUseConversionFunction()
+        {
+            layout.WithMember(o => o.Id, set => set.WithConversionFromString(s => Int32.Parse(s, NumberStyles.AllowHexSpecifier)));
+
+            var entry = new TestObject();
+            var parsedEntity = parser.ParseLine("BEEF", entry);
+
+            parsedEntity.Id.Should().Be(48879);
+        }
+
+        class IdHexConverter : TypeConverterBase<int>
+        {
+            protected override int ConvertFrom(string source, PropertyInfo targetProperty)
+            {
+                return Int32.Parse(source, NumberStyles.AllowHexSpecifier);
+            }
+
+            protected override string ConvertTo(int source, PropertyInfo sourceProperty)
+            {
+                return source.ToString("X");
+            }
+        }
+    }
+}

--- a/src/FlatFile.Tests/FixedLength/FixedLengthErrorHandlingTests.cs
+++ b/src/FlatFile.Tests/FixedLength/FixedLengthErrorHandlingTests.cs
@@ -30,7 +30,7 @@ STest Description    00044";
 
             lineParserFactory = new FixedLengthLineParserFactory(new Dictionary<Type, Type>
             {
-                [typeof(Record)] = typeof(FakeLineParser)
+                { typeof(Record),  typeof(FakeLineParser) }
             });
         }
 

--- a/src/FlatFile.Tests/FixedLength/FixedLengthErrorHandlingTests.cs
+++ b/src/FlatFile.Tests/FixedLength/FixedLengthErrorHandlingTests.cs
@@ -1,0 +1,95 @@
+﻿using FakeItEasy;
+using FlatFile.Core;
+using FlatFile.Core.Base;
+using FlatFile.FixedLength;
+using FlatFile.FixedLength.Implementation;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Xunit;
+
+namespace FlatFile.Tests.FixedLength
+{
+    public class FixedLengthErrorHandlingTests
+    {
+        private ILayoutDescriptor<IFixedFieldSettingsContainer> layout;
+        readonly IFixedLengthLineParserFactory lineParserFactory;
+        readonly IList<FlatFileErrorContext> errorContexts = new List<FlatFileErrorContext>();
+
+        const string TestData = 
+@"STest Description    00042
+STest Description    00043
+STest Description    00044";
+
+        public FixedLengthErrorHandlingTests()
+        {
+            layout = A.Fake<ILayoutDescriptor<IFixedFieldSettingsContainer>>();
+            A.CallTo(() => layout.TargetType).Returns(typeof(Record));
+
+            lineParserFactory = new FixedLengthLineParserFactory(new Dictionary<Type, Type>
+            {
+                [typeof(Record)] = typeof(FakeLineParser)
+            });
+        }
+
+        [Fact]
+        public void ErrorContextShouldProvideAccurateInformation()
+        {
+            var engine = new FixedLengthFileEngine(
+                layout,
+                A.Fake<IFixedLengthLineBuilderFactory>(),
+                lineParserFactory,
+                HandleError);
+
+            using (var stream = new MemoryStream(Encoding.Default.GetBytes(TestData)))
+                engine.Read<Record>(stream).ToList();
+
+            Assert.Equal(3, errorContexts.Count);
+            Assert.Equal(new[] { 1, 2, 3 }, errorContexts.Select(ctx => ctx.LineNumber));
+            Assert.Equal(TestData.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries), errorContexts.Select(ctx => ctx.Line));
+            Assert.All(errorContexts, ctx => Assert.Equal("Parsing failed!", ctx.Exception.Message));
+        }
+
+        [Fact]
+        public void MultiEngineErrorContextShouldProvideAccurateInformation()
+        {
+            var engine = new FixedLengthFileMultiEngine(
+                new[] { layout },
+                (l, i) => typeof(Record),
+                A.Fake<IFixedLengthLineBuilderFactory>(),
+                lineParserFactory,
+                HandleError);
+
+            using (var stream = new MemoryStream(Encoding.Default.GetBytes(TestData)))
+                engine.Read(stream);
+
+            Assert.Equal(3, errorContexts.Count);
+            Assert.Equal(new[] { 1, 2, 3 }, errorContexts.Select(ctx => ctx.LineNumber));
+            Assert.Equal(TestData.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries), errorContexts.Select(ctx => ctx.Line));
+            Assert.All(errorContexts, ctx => Assert.Equal("Parsing failed!", ctx.Exception.Message));
+        }
+
+        private bool HandleError(FlatFileErrorContext context)
+        {
+            errorContexts.Add(context);
+            return true;
+        }
+
+        private class FakeLineParser : IFixedLengthLineParser
+        {
+            public FakeLineParser(ILayoutDescriptor<IFixedFieldSettingsContainer> descriptor)
+            {
+
+            }
+
+            public TEntity ParseLine<TEntity>(string line, TEntity entity) where TEntity : new()
+            {
+                throw new Exception("Parsing failed!");
+            }
+        }
+
+        private class Record { }
+    }
+}

--- a/src/FlatFile.Tests/FixedLength/FixedLengthErrorHandlingTests.cs
+++ b/src/FlatFile.Tests/FixedLength/FixedLengthErrorHandlingTests.cs
@@ -60,6 +60,7 @@ STest Description    00044";
                 (l, i) => typeof(Record),
                 A.Fake<IFixedLengthLineBuilderFactory>(),
                 lineParserFactory,
+                new FixedLengthMasterDetailTracker(),
                 HandleError);
 
             using (var stream = new MemoryStream(Encoding.Default.GetBytes(TestData)))

--- a/src/FlatFile.Tests/FixedLength/FixedLengthLineBuilderTests.cs
+++ b/src/FlatFile.Tests/FixedLength/FixedLengthLineBuilderTests.cs
@@ -1,0 +1,68 @@
+﻿namespace FlatFile.Tests.FixedLength
+{
+    using FlatFile.Core.Base;
+    using FlatFile.FixedLength;
+    using FlatFile.FixedLength.Implementation;
+    using FlatFile.Tests.Base.Entities;
+    using FluentAssertions;
+    using System;
+    using System.Globalization;
+    using System.Reflection;
+    using Xunit;
+
+    public class FixedLengthLineBuilderTests
+    {
+        private readonly FixedLengthLineBuilder builder;
+        private readonly IFixedLayout<TestObject> layout;
+
+        public FixedLengthLineBuilderTests()
+        {
+            layout = new FixedLayout<TestObject>();
+
+            builder = new FixedLengthLineBuilder(layout);
+        }
+
+        [Fact]
+        public void BuilderShouldUseTypeConverter()
+        {
+            layout.WithMember(o => o.Id, set => set.WithLength(4).WithTypeConverter<IdHexConverter>());
+
+            var entry = new TestObject
+            {
+                Id = 48879
+            };
+
+            var line = builder.BuildLine(entry);
+
+            line.Should().Be("BEEF");
+        }
+
+        [Fact]
+        public void BuilderShouldUseConversionFunction()
+        {
+            layout.WithMember(o => o.Id, set => set.WithLength(4).WithConversionToString((int id) => id.ToString("X")));
+
+            var entry = new TestObject
+            {
+                Id = 48879
+            };
+
+            var line = builder.BuildLine(entry);
+
+            line.Should().Be("BEEF");
+        }
+
+        class IdHexConverter : TypeConverterBase<int>
+        {
+            protected override int ConvertFrom(string source, PropertyInfo targetProperty)
+            {
+                return Int32.Parse(source, NumberStyles.AllowHexSpecifier);
+            }
+
+            protected override string ConvertTo(int source, PropertyInfo sourceProperty)
+            {
+                return source.ToString("X");
+            }
+        }
+    }
+}

--- a/src/FlatFile.Tests/FixedLength/FixedLengthMasterDetailCustomTests.cs
+++ b/src/FlatFile.Tests/FixedLength/FixedLengthMasterDetailCustomTests.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using FlatFile.Core;
+using FlatFile.Core.Base;
 using FlatFile.FixedLength;
 using FlatFile.FixedLength.Implementation;
 using FluentAssertions;
@@ -136,7 +137,7 @@ D20150512Standalone                     ";
                                                     },
                                                     new FixedLengthLineBuilderFactory(),
                                                     new FixedLengthLineParserFactory(),
-                                                    new MasterDetailTracker(
+                                                    new MasterDetailTrackerBase(
                                                         x => x.GetType().GetCustomAttribute<MasterAttribute>(true) != null,
                                                         x => x.GetType().GetCustomAttribute<DetailAttribute>(true) != null,
                                                         (master, detail) => ((HeaderRecord)master).DetailRecords.Add((DetailRecord)detail)));

--- a/src/FlatFile.Tests/FixedLength/FixedLengthMasterDetailTests.cs
+++ b/src/FlatFile.Tests/FixedLength/FixedLengthMasterDetailTests.cs
@@ -127,7 +127,7 @@ D20150512Standalone                     ";
                                                     },
                                                     new FixedLengthLineBuilderFactory(),
                                                     new FixedLengthLineParserFactory(),
-                                                    new MasterDetailTracker());
+                                                    new FixedLengthMasterDetailTracker());
         }
 
         [Fact]

--- a/src/FlatFile.Tests/FixedLength/FixedLengthMultiEngineTests.cs
+++ b/src/FlatFile.Tests/FixedLength/FixedLengthMultiEngineTests.cs
@@ -116,7 +116,7 @@ D20150323Another Description ";
                                                     },
                                                     new FixedLengthLineBuilderFactory(),
                                                     new FixedLengthLineParserFactory(),
-                                                    new MasterDetailTracker()) {HasHeader = true};
+                                                    new FixedLengthMasterDetailTracker()) {HasHeader = true};
         }
 
         [Fact]

--- a/src/FlatFile.Tests/FixedLength/FixedLengthMultiEngineTests.cs
+++ b/src/FlatFile.Tests/FixedLength/FixedLengthMultiEngineTests.cs
@@ -115,7 +115,8 @@ D20150323Another Description ";
                                                         }
                                                     },
                                                     new FixedLengthLineBuilderFactory(),
-                                                    new FixedLengthLineParserFactory()) {HasHeader = true};
+                                                    new FixedLengthLineParserFactory(),
+                                                    new MasterDetailTracker()) {HasHeader = true};
         }
 
         [Fact]

--- a/src/FlatFile.Tests/FlatFile.Tests.csproj
+++ b/src/FlatFile.Tests/FlatFile.Tests.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -13,6 +14,8 @@
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -79,11 +82,14 @@
     <Compile Include="Delimited\DelimitedAttributeMappingIntegrationTests.cs" />
     <Compile Include="Delimited\DelimitedIntegrationTests.cs" />
     <Compile Include="Delimited\DelimitedLayoutTests.cs" />
+    <Compile Include="Delimited\DelimitedLineBuilderTests.cs" />
+    <Compile Include="Delimited\DelimitedLineParserTests.cs" />
     <Compile Include="Delimited\DelimitedMultiEngineTests.cs" />
     <Compile Include="Delimited\DelimitedWithHeaderIntegrationTests.cs" />
     <Compile Include="FixedLength\FixedLayoutTests.cs" />
     <Compile Include="FixedLength\FixedLengthAttributeMappingIntegrationTests.cs" />
     <Compile Include="FixedLength\FixedLengthIntegrationTests.cs" />
+    <Compile Include="FixedLength\FixedLengthLineBuilderTests.cs" />
     <Compile Include="FixedLength\FixedLengthLineParserTests.cs" />
     <Compile Include="FixedLength\FixedLengthMasterDetailTests.cs" />
     <Compile Include="FixedLength\FixedLengthMultiEngineTests.cs" />
@@ -138,6 +144,12 @@
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/FlatFile.Tests/FlatFile.Tests.csproj
+++ b/src/FlatFile.Tests/FlatFile.Tests.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -13,6 +14,8 @@
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -81,8 +84,10 @@
     <Compile Include="Delimited\DelimitedLayoutTests.cs" />
     <Compile Include="Delimited\DelimitedMultiEngineTests.cs" />
     <Compile Include="Delimited\DelimitedWithHeaderIntegrationTests.cs" />
+    <Compile Include="Delimited\DelimitedErrorHandlingTests.cs" />
     <Compile Include="FixedLength\FixedLayoutTests.cs" />
     <Compile Include="FixedLength\FixedLengthAttributeMappingIntegrationTests.cs" />
+    <Compile Include="FixedLength\FixedLengthErrorHandlingTests.cs" />
     <Compile Include="FixedLength\FixedLengthIntegrationTests.cs" />
     <Compile Include="FixedLength\FixedLengthLineParserTests.cs" />
     <Compile Include="FixedLength\FixedLengthMasterDetailTests.cs" />
@@ -138,6 +143,12 @@
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/FlatFile.Tests/FlatFile.Tests.csproj
+++ b/src/FlatFile.Tests/FlatFile.Tests.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -13,6 +14,8 @@
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -138,6 +141,12 @@
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/FlatFile.Tests/FlatFile.Tests.csproj
+++ b/src/FlatFile.Tests/FlatFile.Tests.csproj
@@ -86,6 +86,7 @@
     <Compile Include="Delimited\DelimitedWithHeaderIntegrationTests.cs" />
     <Compile Include="FixedLength\FixedLayoutTests.cs" />
     <Compile Include="FixedLength\FixedLengthAttributeMappingIntegrationTests.cs" />
+    <Compile Include="FixedLength\FixedLengthMasterDetailCustomTests.cs" />
     <Compile Include="FixedLength\FixedLengthIntegrationTests.cs" />
     <Compile Include="FixedLength\FixedLengthLineParserTests.cs" />
     <Compile Include="FixedLength\FixedLengthMasterDetailTests.cs" />

--- a/src/FlatFile.Tests/packages.config
+++ b/src/FlatFile.Tests/packages.config
@@ -11,4 +11,5 @@
   <package id="xunit.extensibility.core" version="2.1.0" targetFramework="net45" />
   <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="net45" />
   <package id="xunit.runner.console" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.runner.visualstudio" version="2.1.0" targetFramework="net45" />
 </packages>

--- a/src/FlatFile.sln
+++ b/src/FlatFile.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.27703.2000
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FlatFile.Core", "FlatFile.Core\FlatFile.Core.csproj", "{1CB90052-B97A-4AD4-B9FD-20A22914D129}"
 EndProject
@@ -9,6 +9,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FlatFile.FixedLength", "Fla
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "assets", "assets", "{874AF755-A91B-434F-9679-35BEBC8B7D9F}"
 	ProjectSection(SolutionItems) = preProject
+		..\.gitignore = ..\.gitignore
 		..\appveyor.yml = ..\appveyor.yml
 		..\nuspecs\FlatFile.Core.Attributes.nuspec = ..\nuspecs\FlatFile.Core.Attributes.nuspec
 		..\nuspecs\FlatFile.Core.nuspec = ..\nuspecs\FlatFile.Core.nuspec
@@ -78,5 +79,8 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{1484D999-2EC8-4D73-ACCC-17E25F98E20F} = {58C25CA0-7F53-46A6-873E-1E1B18D65222}
 		{7B8FE44C-7725-40C2-AED4-7573F5ABAAB7} = {58C25CA0-7F53-46A6-873E-1E1B18D65222}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {1CDB73F9-C29E-473D-96C3-D0FA67CCCF42}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
Using the fluent layout classes for record configuration, it is almost possible to completely decouple record models from the FlatFile library. The only exception is in the case of master/detail record relationships. This currently requires the use of the interfaces `IMasterRecord` and `IDetailRecord`.

In this pull request, I have factored out master-detail record handling into a pluggable mechanism. The stateful side of master-detail tracking can be replaced in its entirety using an implementation of the `IMasterDetailTracker` interface, or just the checking of whether records are a master or detail and what to do with them can be changed by providing a `MasterDetailTrackerBase` instance with different constructor parameters.

The changes should be backward compatible since the default implementation preserves the current behavior.

I have added tests using, somewhat ironically, an attribute-based implementation of master-detail records. It is really just based on the existing master-detail tests.

As a side note, I was not able to execute the tests in Visual Studio until I installed the xUnit Visual Studio runner package.

I welcome feedback and hope that this could be merged.