### PR TITLE
Provide line number in error handler

### DIFF
--- a/src/FlatFile.Core/Base/FlatFileEngine.cs
+++ b/src/FlatFile.Core/Base/FlatFileEngine.cs
@@ -18,7 +18,7 @@ namespace FlatFile.Core.Base
         /// <summary>
         /// The handle entry read error func
         /// </summary>
-        private readonly Func<string, Exception, bool> _handleEntryReadError;
+        private readonly Func<FlatFileErrorContext, bool> _handleEntryReadError;
 
         /// <summary>
         /// Gets the line builder.
@@ -42,7 +42,7 @@ namespace FlatFile.Core.Base
         /// Initializes a new instance of the <see cref="FlatFileEngine{TFieldSettings, TLayoutDescriptor}"/> class.
         /// </summary>
         /// <param name="handleEntryReadError">The handle entry read error.</param>
-        protected FlatFileEngine(Func<string, Exception, bool> handleEntryReadError = null)
+        protected FlatFileEngine(Func<FlatFileErrorContext, bool> handleEntryReadError = null)
         {
             _handleEntryReadError = handleEntryReadError;
         }
@@ -85,7 +85,7 @@ namespace FlatFile.Core.Base
                         throw;
                     }
 
-                    if (!_handleEntryReadError(line, ex))
+                    if (!_handleEntryReadError(new FlatFileErrorContext(line, lineNumber, ex)))
                     {
                         throw;
                     }

--- a/src/FlatFile.Core/Base/FlatFileErrorContext.cs
+++ b/src/FlatFile.Core/Base/FlatFileErrorContext.cs
@@ -7,6 +7,10 @@
     /// </summary>
     public struct FlatFileErrorContext
     {
+        private readonly string line;
+        private readonly int lineNumber;
+        private readonly Exception exception;
+
         /// <summary>
         /// Initializes a new instance of <see cref="FlatFileErrorContext"/>.
         /// </summary>
@@ -15,24 +19,33 @@
         /// <param name="exception">The error that occurred.</param>
         public FlatFileErrorContext(string line, int lineNumber, Exception exception)
         {
-            Line = line;
-            LineNumber = lineNumber;
-            Exception = exception;
+            this.line = line;
+            this.lineNumber = lineNumber;
+            this.exception = exception;
         }
 
         /// <summary>
         /// The content of the line on which the error occurred.
         /// </summary>
-        public string Line { get; private set; }
+        public string Line
+        {
+            get { return line; }
+        }
 
         /// <summary>
         /// The line numer at which the error occurred.
         /// </summary>
-        public int LineNumber { get; private set; }
+        public int LineNumber
+        {
+            get { return lineNumber; }
+        }
 
         /// <summary>
         /// The error that occurred.
         /// </summary>
-        public Exception Exception { get; private set; }
+        public Exception Exception
+        {
+            get { return exception; }
+        }
     }
 }

--- a/src/FlatFile.Core/Base/FlatFileErrorContext.cs
+++ b/src/FlatFile.Core/Base/FlatFileErrorContext.cs
@@ -1,0 +1,38 @@
+﻿namespace FlatFile.Core.Base
+{
+    using System;
+
+    /// <summary>
+    /// Provides information about a file parsing error.
+    /// </summary>
+    public struct FlatFileErrorContext
+    {
+        /// <summary>
+        /// Initializes a new instance of <see cref="FlatFileErrorContext"/>.
+        /// </summary>
+        /// <param name="line">The content of the line on which the error occurred.</param>
+        /// <param name="lineNumber">The line numer at which the error occurred.</param>
+        /// <param name="exception">The error that occurred.</param>
+        public FlatFileErrorContext(string line, int lineNumber, Exception exception)
+        {
+            Line = line;
+            LineNumber = lineNumber;
+            Exception = exception;
+        }
+
+        /// <summary>
+        /// The content of the line on which the error occurred.
+        /// </summary>
+        public string Line { get; }
+
+        /// <summary>
+        /// The line numer at which the error occurred.
+        /// </summary>
+        public int LineNumber { get; }
+
+        /// <summary>
+        /// The error that occurred.
+        /// </summary>
+        public Exception Exception { get; }
+    }
+}

--- a/src/FlatFile.Core/Base/FlatFileErrorContext.cs
+++ b/src/FlatFile.Core/Base/FlatFileErrorContext.cs
@@ -23,16 +23,16 @@
         /// <summary>
         /// The content of the line on which the error occurred.
         /// </summary>
-        public string Line { get; }
+        public string Line { get; private set; }
 
         /// <summary>
         /// The line numer at which the error occurred.
         /// </summary>
-        public int LineNumber { get; }
+        public int LineNumber { get; private set; }
 
         /// <summary>
         /// The error that occurred.
         /// </summary>
-        public Exception Exception { get; }
+        public Exception Exception { get; private set; }
     }
 }

--- a/src/FlatFile.Core/FlatFile.Core.csproj
+++ b/src/FlatFile.Core/FlatFile.Core.csproj
@@ -98,6 +98,7 @@
     <Compile Include="Base\FieldsContainer.cs" />
     <Compile Include="Base\FieldSettingsBase.cs" />
     <Compile Include="Base\FlatFileEngine.cs" />
+    <Compile Include="Base\FlatFileErrorContext.cs" />
     <Compile Include="Base\LayoutBase.cs" />
     <Compile Include="Base\LayoutDescriptorBase.cs" />
     <Compile Include="Base\LineBulderBase.cs" />

--- a/src/FlatFile.Delimited/Implementation/DelimetedFileMultiEngine.cs
+++ b/src/FlatFile.Delimited/Implementation/DelimetedFileMultiEngine.cs
@@ -18,7 +18,7 @@ namespace FlatFile.Delimited.Implementation
         /// <summary>
         /// The handle entry read error func
         /// </summary>
-        readonly Func<string, Exception, bool> handleEntryReadError;
+        readonly Func<FlatFileErrorContext, bool> handleEntryReadError;
         /// <summary>
         /// The layout descriptors for this engine
         /// </summary>
@@ -58,7 +58,7 @@ namespace FlatFile.Delimited.Implementation
             Func<string, Type> typeSelectorFunc,
             IDelimitedLineBuilderFactory lineBuilderFactory,
             IDelimitedLineParserFactory lineParserFactory,
-            Func<string, Exception, bool> handleEntryReadError = null)
+            Func<FlatFileErrorContext, bool> handleEntryReadError = null)
         {
             if (typeSelectorFunc == null) throw new ArgumentNullException("typeSelectorFunc");
             this.layoutDescriptors = layoutDescriptors.ToList();
@@ -170,7 +170,7 @@ namespace FlatFile.Delimited.Implementation
                         throw;
                     }
 
-                    if (!handleEntryReadError(line, ex))
+                    if (!handleEntryReadError(new FlatFileErrorContext(line, lineNumber, ex)))
                     {
                         throw;
                     }

--- a/src/FlatFile.Delimited/Implementation/DelimitedFileEngine.cs
+++ b/src/FlatFile.Delimited/Implementation/DelimitedFileEngine.cs
@@ -38,7 +38,7 @@ namespace FlatFile.Delimited.Implementation
             IDelimitedLayoutDescriptor layoutDescriptor,
             IDelimitedLineBuilderFactory builderFactory,
             IDelimitedLineParserFactory parserFactory, 
-            Func<string, Exception, bool> handleEntryReadError = null)
+            Func<FlatFileErrorContext, bool> handleEntryReadError = null)
             : base(handleEntryReadError)
         {
             _builderFactory = builderFactory;

--- a/src/FlatFile.Delimited/Implementation/DelimitedFileEngineFactory.cs
+++ b/src/FlatFile.Delimited/Implementation/DelimitedFileEngineFactory.cs
@@ -51,10 +51,25 @@ namespace FlatFile.Delimited.Implementation
                 descriptor,
                 new DelimitedLineBuilderFactory(),
                 new DelimitedLineParserFactory(),
-                handleEntryReadError);
+                ctx => handleEntryReadError(ctx.Line, ctx.Exception));
         }
 
-
+        /// <summary>
+        /// Gets the <see cref="IFlatFileEngine" />.
+        /// </summary>
+        /// <param name="descriptor">The descriptor.</param>
+        /// <param name="handleEntryReadError">The handle entry read error func.</param>
+        /// <returns>IFlatFileEngine.</returns>
+        public IFlatFileEngine GetEngine(
+            IDelimitedLayoutDescriptor descriptor,
+            Func<FlatFileErrorContext, bool> handleEntryReadError)
+        {
+            return new DelimitedFileEngine(
+                descriptor,
+                new DelimitedLineBuilderFactory(),
+                new DelimitedLineParserFactory(),
+                handleEntryReadError);
+        }
 
         /// <summary>
         /// Gets the <see cref="IFlatFileMultiEngine"/>.
@@ -67,6 +82,26 @@ namespace FlatFile.Delimited.Implementation
             IEnumerable<IDelimitedLayoutDescriptor> layoutDescriptors,
             Func<string, Type> typeSelectorFunc,
             Func<string, Exception, bool> handleEntryReadError = null)
+        {
+            return new DelimitedFileMultiEngine(
+                layoutDescriptors,
+                typeSelectorFunc,
+                new DelimitedLineBuilderFactory(),
+                lineParserFactory,
+                ctx => handleEntryReadError(ctx.Line, ctx.Exception));
+        }
+
+        /// <summary>
+        /// Gets the <see cref="IFlatFileMultiEngine"/>.
+        /// </summary>
+        /// <param name="layoutDescriptors">The layout descriptors.</param>
+        /// <param name="typeSelectorFunc">The type selector function.</param>
+        /// <param name="handleEntryReadError">The handle entry read error func.</param>
+        /// <returns>IFlatFileMultiEngine.</returns>
+        public IFlatFileMultiEngine GetEngine(
+            IEnumerable<IDelimitedLayoutDescriptor> layoutDescriptors,
+            Func<string, Type> typeSelectorFunc,
+            Func<FlatFileErrorContext, bool> handleEntryReadError)
         {
             return new DelimitedFileMultiEngine(
                 layoutDescriptors,

--- a/src/FlatFile.FixedLength/Implementation/FixedLengthFileEngine.cs
+++ b/src/FlatFile.FixedLength/Implementation/FixedLengthFileEngine.cs
@@ -33,7 +33,7 @@ namespace FlatFile.FixedLength.Implementation
             ILayoutDescriptor<IFixedFieldSettingsContainer> layoutDescriptor,
             IFixedLengthLineBuilderFactory lineBuilderFactory,
             IFixedLengthLineParserFactory lineParserFactory,
-            Func<string, Exception, bool> handleEntryReadError = null) : base(handleEntryReadError)
+            Func<FlatFileErrorContext, bool> handleEntryReadError = null) : base(handleEntryReadError)
         {
             this.lineBuilderFactory = lineBuilderFactory;
             this.lineParserFactory = lineParserFactory;

--- a/src/FlatFile.FixedLength/Implementation/FixedLengthFileEngineFactory.cs
+++ b/src/FlatFile.FixedLength/Implementation/FixedLengthFileEngineFactory.cs
@@ -48,7 +48,24 @@ namespace FlatFile.FixedLength.Implementation
             return new FixedLengthFileEngine(
                 descriptor, 
                 new FixedLengthLineBuilderFactory(),
-                lineParserFactory, 
+                lineParserFactory,
+                ctx => handleEntryReadError(ctx.Line, ctx.Exception));
+        }
+
+        /// <summary>
+        /// Gets the <see cref="IFlatFileEngine" />.
+        /// </summary>
+        /// <param name="descriptor">The descriptor.</param>
+        /// <param name="handleEntryReadError">The handle entry read error func.</param>
+        /// <returns>IFlatFileEngine.</returns>
+        public IFlatFileEngine GetEngine(
+            ILayoutDescriptor<IFixedFieldSettingsContainer> descriptor,
+            Func<FlatFileErrorContext, bool> handleEntryReadError)
+        {
+            return new FixedLengthFileEngine(
+                descriptor,
+                new FixedLengthLineBuilderFactory(),
+                lineParserFactory,
                 handleEntryReadError);
         }
 
@@ -63,6 +80,26 @@ namespace FlatFile.FixedLength.Implementation
             IEnumerable<ILayoutDescriptor<IFixedFieldSettingsContainer>> layoutDescriptors,
             Func<string, int, Type> typeSelectorFunc,
             Func<string, Exception, bool> handleEntryReadError = null)
+        {
+            return new FixedLengthFileMultiEngine(
+                layoutDescriptors,
+                typeSelectorFunc,
+                new FixedLengthLineBuilderFactory(),
+                lineParserFactory,
+                ctx => handleEntryReadError(ctx.Line, ctx.Exception));
+        }
+
+        /// <summary>
+        /// Gets the <see cref="IFlatFileMultiEngine"/>.
+        /// </summary>
+        /// <param name="layoutDescriptors">The layout descriptors.</param>
+        /// <param name="typeSelectorFunc">The type selector function.</param>
+        /// <param name="handleEntryReadError">The handle entry read error func.</param>
+        /// <returns>IFlatFileMultiEngine.</returns>
+        public IFlatFileMultiEngine GetEngine(
+            IEnumerable<ILayoutDescriptor<IFixedFieldSettingsContainer>> layoutDescriptors,
+            Func<string, int, Type> typeSelectorFunc,
+            Func<FlatFileErrorContext, bool> handleEntryReadError)
         {
             return new FixedLengthFileMultiEngine(
                 layoutDescriptors,

--- a/src/FlatFile.FixedLength/Implementation/FixedLengthFileMultiEngine.cs
+++ b/src/FlatFile.FixedLength/Implementation/FixedLengthFileMultiEngine.cs
@@ -18,7 +18,7 @@ namespace FlatFile.FixedLength.Implementation
         /// <summary>
         /// The handle entry read error func
         /// </summary>
-        readonly Func<string, Exception, bool> handleEntryReadError;
+        readonly Func<FlatFileErrorContext, bool> handleEntryReadError;
         /// <summary>
         /// The layout descriptors for this engine
         /// </summary>
@@ -58,7 +58,7 @@ namespace FlatFile.FixedLength.Implementation
             Func<string, int, Type> typeSelectorFunc,
             IFixedLengthLineBuilderFactory lineBuilderFactory,
             IFixedLengthLineParserFactory lineParserFactory,
-            Func<string, Exception, bool> handleEntryReadError = null)
+            Func<FlatFileErrorContext, bool> handleEntryReadError = null)
         {
             if (typeSelectorFunc == null) throw new ArgumentNullException("typeSelectorFunc");
             this.layoutDescriptors = layoutDescriptors.ToList();
@@ -191,7 +191,7 @@ namespace FlatFile.FixedLength.Implementation
                         throw;
                     }
 
-                    if (!handleEntryReadError(line, ex))
+                    if (!handleEntryReadError(new FlatFileErrorContext(line, lineNumber, ex)))
                     {
                         throw;
                     }

--- a/src/FlatFile.Tests/Delimited/DelimitedErrorHandlingTests.cs
+++ b/src/FlatFile.Tests/Delimited/DelimitedErrorHandlingTests.cs
@@ -31,9 +31,9 @@ S,Test Description,00044";
             A.CallTo(() => lineParserFactory.GetParser(A<IDelimitedLayoutDescriptor>.Ignored))
                 .Returns(new FakeLineParser());
                 
-                new DelimitedLineParserFactory(new Dictionary<Type, Type>
+            new DelimitedLineParserFactory(new Dictionary<Type, Type>
             {
-                [typeof(Record)] = typeof(FakeLineParser)
+                { typeof(Record), typeof(FakeLineParser) }
             });
         }
 

--- a/src/FlatFile.Tests/Delimited/DelimitedErrorHandlingTests.cs
+++ b/src/FlatFile.Tests/Delimited/DelimitedErrorHandlingTests.cs
@@ -1,0 +1,93 @@
+﻿using FakeItEasy;
+using FlatFile.Core.Base;
+using FlatFile.Delimited;
+using FlatFile.Delimited.Implementation;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Xunit;
+
+namespace FlatFile.Tests.Delimited
+{
+    public class DelimitedErrorHandlingTests
+    {
+        private IDelimitedLayoutDescriptor layout;
+        readonly IDelimitedLineParserFactory lineParserFactory;
+        readonly IList<FlatFileErrorContext> errorContexts = new List<FlatFileErrorContext>();
+
+        const string TestData = 
+@"S,Test Description,00042
+S,Test Description,00043
+S,Test Description,00044";
+
+        public DelimitedErrorHandlingTests()
+        {
+            layout = A.Fake<IDelimitedLayoutDescriptor>();
+            A.CallTo(() => layout.TargetType).Returns(typeof(Record));
+
+            lineParserFactory = A.Fake<IDelimitedLineParserFactory>();
+            A.CallTo(() => lineParserFactory.GetParser(A<IDelimitedLayoutDescriptor>.Ignored))
+                .Returns(new FakeLineParser());
+                
+                new DelimitedLineParserFactory(new Dictionary<Type, Type>
+            {
+                [typeof(Record)] = typeof(FakeLineParser)
+            });
+        }
+
+        [Fact]
+        public void ErrorContextShouldProvideAccurateInformation()
+        {
+            var engine = new DelimitedFileEngine(
+                layout,
+                A.Fake<IDelimitedLineBuilderFactory>(),
+                lineParserFactory,
+                HandleError);
+
+            using (var stream = new MemoryStream(Encoding.Default.GetBytes(TestData)))
+                engine.Read<Record>(stream).ToList();
+
+            Assert.Equal(3, errorContexts.Count);
+            Assert.Equal(new[] { 1, 2, 3 }, errorContexts.Select(ctx => ctx.LineNumber));
+            Assert.Equal(TestData.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries), errorContexts.Select(ctx => ctx.Line));
+            Assert.All(errorContexts, ctx => Assert.Equal("Parsing failed!", ctx.Exception.Message));
+        }
+
+        [Fact]
+        public void MultiEngineErrorContextShouldProvideAccurateInformation()
+        {
+            var engine = new DelimitedFileMultiEngine(
+                new[] { layout },
+                l => typeof(Record),
+                A.Fake<IDelimitedLineBuilderFactory>(),
+                lineParserFactory,
+                HandleError);
+
+            using (var stream = new MemoryStream(Encoding.Default.GetBytes(TestData)))
+                engine.Read(stream);
+
+            Assert.Equal(3, errorContexts.Count);
+            Assert.Equal(new[] { 1, 2, 3 }, errorContexts.Select(ctx => ctx.LineNumber));
+            Assert.Equal(TestData.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries), errorContexts.Select(ctx => ctx.Line));
+            Assert.All(errorContexts, ctx => Assert.Equal("Parsing failed!", ctx.Exception.Message));
+        }
+
+        private bool HandleError(FlatFileErrorContext context)
+        {
+            errorContexts.Add(context);
+            return true;
+        }
+
+        private class FakeLineParser : IDelimitedLineParser
+        {
+            public TEntity ParseLine<TEntity>(string line, TEntity entity) where TEntity : new()
+            {
+                throw new Exception("Parsing failed!");
+            }
+        }
+
+        private class Record { }
+    }
+}

--- a/src/FlatFile.Tests/FixedLength/FixedLengthErrorHandlingTests.cs
+++ b/src/FlatFile.Tests/FixedLength/FixedLengthErrorHandlingTests.cs
@@ -30,7 +30,7 @@ STest Description    00044";
 
             lineParserFactory = new FixedLengthLineParserFactory(new Dictionary<Type, Type>
             {
-                [typeof(Record)] = typeof(FakeLineParser)
+                { typeof(Record),  typeof(FakeLineParser) }
             });
         }
 

--- a/src/FlatFile.Tests/FixedLength/FixedLengthErrorHandlingTests.cs
+++ b/src/FlatFile.Tests/FixedLength/FixedLengthErrorHandlingTests.cs
@@ -1,0 +1,95 @@
+﻿using FakeItEasy;
+using FlatFile.Core;
+using FlatFile.Core.Base;
+using FlatFile.FixedLength;
+using FlatFile.FixedLength.Implementation;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Xunit;
+
+namespace FlatFile.Tests.FixedLength
+{
+    public class FixedLengthErrorHandlingTests
+    {
+        private ILayoutDescriptor<IFixedFieldSettingsContainer> layout;
+        readonly IFixedLengthLineParserFactory lineParserFactory;
+        readonly IList<FlatFileErrorContext> errorContexts = new List<FlatFileErrorContext>();
+
+        const string TestData = 
+@"STest Description    00042
+STest Description    00043
+STest Description    00044";
+
+        public FixedLengthErrorHandlingTests()
+        {
+            layout = A.Fake<ILayoutDescriptor<IFixedFieldSettingsContainer>>();
+            A.CallTo(() => layout.TargetType).Returns(typeof(Record));
+
+            lineParserFactory = new FixedLengthLineParserFactory(new Dictionary<Type, Type>
+            {
+                [typeof(Record)] = typeof(FakeLineParser)
+            });
+        }
+
+        [Fact]
+        public void ErrorContextShouldProvideAccurateInformation()
+        {
+            var engine = new FixedLengthFileEngine(
+                layout,
+                A.Fake<IFixedLengthLineBuilderFactory>(),
+                lineParserFactory,
+                HandleError);
+
+            using (var stream = new MemoryStream(Encoding.Default.GetBytes(TestData)))
+                engine.Read<Record>(stream).ToList();
+
+            Assert.Equal(3, errorContexts.Count);
+            Assert.Equal(new[] { 1, 2, 3 }, errorContexts.Select(ctx => ctx.LineNumber));
+            Assert.Equal(TestData.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries), errorContexts.Select(ctx => ctx.Line));
+            Assert.All(errorContexts, ctx => Assert.Equal("Parsing failed!", ctx.Exception.Message));
+        }
+
+        [Fact]
+        public void MultiEngineErrorContextShouldProvideAccurateInformation()
+        {
+            var engine = new FixedLengthFileMultiEngine(
+                new[] { layout },
+                (l, i) => typeof(Record),
+                A.Fake<IFixedLengthLineBuilderFactory>(),
+                lineParserFactory,
+                HandleError);
+
+            using (var stream = new MemoryStream(Encoding.Default.GetBytes(TestData)))
+                engine.Read(stream);
+
+            Assert.Equal(3, errorContexts.Count);
+            Assert.Equal(new[] { 1, 2, 3 }, errorContexts.Select(ctx => ctx.LineNumber));
+            Assert.Equal(TestData.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries), errorContexts.Select(ctx => ctx.Line));
+            Assert.All(errorContexts, ctx => Assert.Equal("Parsing failed!", ctx.Exception.Message));
+        }
+
+        private bool HandleError(FlatFileErrorContext context)
+        {
+            errorContexts.Add(context);
+            return true;
+        }
+
+        private class FakeLineParser : IFixedLengthLineParser
+        {
+            public FakeLineParser(ILayoutDescriptor<IFixedFieldSettingsContainer> descriptor)
+            {
+
+            }
+
+            public TEntity ParseLine<TEntity>(string line, TEntity entity) where TEntity : new()
+            {
+                throw new Exception("Parsing failed!");
+            }
+        }
+
+        private class Record { }
+    }
+}

--- a/src/FlatFile.Tests/FlatFile.Tests.csproj
+++ b/src/FlatFile.Tests/FlatFile.Tests.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -13,6 +14,8 @@
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -81,8 +84,10 @@
     <Compile Include="Delimited\DelimitedLayoutTests.cs" />
     <Compile Include="Delimited\DelimitedMultiEngineTests.cs" />
     <Compile Include="Delimited\DelimitedWithHeaderIntegrationTests.cs" />
+    <Compile Include="Delimited\DelimitedErrorHandlingTests.cs" />
     <Compile Include="FixedLength\FixedLayoutTests.cs" />
     <Compile Include="FixedLength\FixedLengthAttributeMappingIntegrationTests.cs" />
+    <Compile Include="FixedLength\FixedLengthErrorHandlingTests.cs" />
     <Compile Include="FixedLength\FixedLengthIntegrationTests.cs" />
     <Compile Include="FixedLength\FixedLengthLineParserTests.cs" />
     <Compile Include="FixedLength\FixedLengthMasterDetailTests.cs" />
@@ -138,6 +143,12 @@
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/FlatFile.Tests/packages.config
+++ b/src/FlatFile.Tests/packages.config
@@ -11,4 +11,5 @@
   <package id="xunit.extensibility.core" version="2.1.0" targetFramework="net45" />
   <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="net45" />
   <package id="xunit.runner.console" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.runner.visualstudio" version="2.1.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
I would find it useful to have the line number available for error handling.

This pull request includes backward compatible refactoring to introduce a `FlatFileErrorContext` object that contains all relevant information about a parsing error. This should simplify the introduction of any more error details in the future. In addition to the existing properties, `Line` and `Exception`, I added the line number to this context.