### PR TITLE
Type Converter Enhancements

### DIFF
--- a/src/FlatFile.Benchmark/Converters/CsvHelperTypeConverterForCustomType.cs
+++ b/src/FlatFile.Benchmark/Converters/CsvHelperTypeConverterForCustomType.cs
@@ -14,12 +14,12 @@
 
         public string ConvertToString(CsvHelperTypeConversion.TypeConverterOptions options, object value)
         {
-            return converter.ConvertToString(value);
+            return converter.ConvertToString(value, null);
         }
 
         public object ConvertFromString(CsvHelperTypeConversion.TypeConverterOptions options, string text)
         {
-            return converter.ConvertFromString(text);
+            return converter.ConvertFromString(text, null);
         }
 
         public bool CanConvertFrom(Type type)

--- a/src/FlatFile.Benchmark/Converters/FlatFileTypeConverterForCustomType.cs
+++ b/src/FlatFile.Benchmark/Converters/FlatFileTypeConverterForCustomType.cs
@@ -1,6 +1,7 @@
 ﻿namespace FlatFile.Benchmark.Converters
 {
     using System;
+    using System.Reflection;
     using FlatFile.Benchmark.Entities;
     using FlatFile.Core;
 
@@ -16,13 +17,13 @@
             return type == typeof (CustomType);
         }
 
-        public string ConvertToString(object source)
+        public string ConvertToString(object source, PropertyInfo sourceProperty)
         {
             var obj = (CustomType)source;
             return string.Format("{0}|{1}|{2}", obj.First, obj.Second, obj.Third);
         }
 
-        public object ConvertFromString(string source)
+        public object ConvertFromString(string source, PropertyInfo targetProperty)
         {
             var values = source.Split('|');
 

--- a/src/FlatFile.Core/Base/FlatFileEngine.cs
+++ b/src/FlatFile.Core/Base/FlatFileEngine.cs
@@ -24,7 +24,7 @@ namespace FlatFile.Core.Base
         /// Gets the line builder.
         /// </summary>
         /// <value>The line builder.</value>
-        protected abstract ILineBulder LineBuilder { get; }
+        protected abstract ILineBuilder LineBuilder { get; }
 
         /// <summary>
         /// Gets the line parser.

--- a/src/FlatFile.Core/Base/LineBuilderBase.cs
+++ b/src/FlatFile.Core/Base/LineBuilderBase.cs
@@ -21,7 +21,7 @@ namespace FlatFile.Core.Base
         protected virtual string GetStringValueFromField(TFieldSettings field, object fieldValue)
         {
             string lineValue = fieldValue != null
-                ? fieldValue.ToString()
+                ? ConvertToString(field, fieldValue)
                 : field.NullValue ?? string.Empty;
 
             lineValue = TransformFieldValue(field, lineValue);
@@ -32,6 +32,15 @@ namespace FlatFile.Core.Base
         protected virtual string TransformFieldValue(TFieldSettings field, string lineValue)
         {
             return lineValue;
+        }
+
+        private static string ConvertToString(TFieldSettings field, object fieldValue)
+        {
+            var converter = field.TypeConverter;
+            if (converter != null && converter.CanConvertTo(typeof(string)) && converter.CanConvertFrom(field.PropertyInfo.PropertyType))
+                return field.TypeConverter.ConvertToString(fieldValue, field.PropertyInfo);
+
+            return fieldValue.ToString();
         }
     }
 }

--- a/src/FlatFile.Core/Base/LineBuilderBase.cs
+++ b/src/FlatFile.Core/Base/LineBuilderBase.cs
@@ -1,12 +1,12 @@
 namespace FlatFile.Core.Base
 {
-    public abstract class LineBulderBase<TLayoutDescriptor, TFieldSettings> : ILineBulder
+    public abstract class LineBuilderBase<TLayoutDescriptor, TFieldSettings> : ILineBuilder
         where TLayoutDescriptor : ILayoutDescriptor<TFieldSettings>
         where TFieldSettings : IFieldSettingsContainer 
     {
         private readonly TLayoutDescriptor _descriptor;
 
-        protected LineBulderBase(TLayoutDescriptor descriptor)
+        protected LineBuilderBase(TLayoutDescriptor descriptor)
         {
             this._descriptor = descriptor;
         }

--- a/src/FlatFile.Core/Base/LineParserBase.cs
+++ b/src/FlatFile.Core/Base/LineParserBase.cs
@@ -1,6 +1,7 @@
 namespace FlatFile.Core.Base
 {
     using System;
+    using System.Reflection;
     using FlatFile.Core.Extensions;
 
     public abstract class LineParserBase<TLayoutDescriptor, TFieldSettings> : ILineParser
@@ -39,7 +40,7 @@ namespace FlatFile.Core.Base
 
             object obj;
             
-            if (!fieldSettings.TypeConverter.ConvertFromStringTo(memberValue, type, out obj))
+            if (!fieldSettings.TypeConverter.ConvertFromStringTo(memberValue, type, fieldSettings.PropertyInfo, out obj))
             {
                 obj = memberValue.Convert(type);
             }
@@ -56,11 +57,11 @@ namespace FlatFile.Core.Base
     public static class TypeConverterExtensions
     {
 
-        public static bool ConvertFromStringTo(this ITypeConverter converter, string source, Type targetType, out object obj)
+        public static bool ConvertFromStringTo(this ITypeConverter converter, string source, Type targetType, PropertyInfo targetProperty, out object obj)
         {
             if (converter != null && converter.CanConvertFrom(typeof(string)) && converter.CanConvertTo(targetType))
             {
-                obj = converter.ConvertFromString(source);
+                obj = converter.ConvertFromString(source, targetProperty);
                 return true;
             }
 

--- a/src/FlatFile.Core/Base/TypeConverterBase.cs
+++ b/src/FlatFile.Core/Base/TypeConverterBase.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Reflection;
+
+namespace FlatFile.Core.Base
+{
+    /// <summary>
+    /// A generic base class for converting between strings and a given type.
+    /// </summary>
+    /// <typeparam name="TValue">The type to convert to and from a string.</typeparam>
+    public abstract class TypeConverterBase<TValue> : ITypeConverter
+    {
+        public virtual bool CanConvertFrom(Type type)
+        {
+            return type == typeof(string) || type == typeof(TValue);
+        }
+
+        public virtual bool CanConvertTo(Type type)
+        {
+            return type == typeof(string) || type == typeof(TValue);
+        }
+
+        public object ConvertFromString(string source, PropertyInfo targetProperty)
+        {
+            return ConvertFrom(source, targetProperty);
+        }
+
+        protected abstract TValue ConvertFrom(string source, PropertyInfo targetProperty);
+
+        public string ConvertToString(object source, PropertyInfo sourceProperty)
+        {
+            return ConvertTo((TValue)source, sourceProperty);
+        }
+
+        protected abstract string ConvertTo(TValue source, PropertyInfo sourceProperty);
+    }
+}

--- a/src/FlatFile.Core/DelegatingTypeConverter.cs
+++ b/src/FlatFile.Core/DelegatingTypeConverter.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Reflection;
+
+namespace FlatFile.Core
+{
+    /// <summary>
+    /// An implementation of <see cref="ITypeConverter"/> that uses delegates for conversion.
+    /// </summary>
+    class DelegatingTypeConverter<TProperty> : ITypeConverter
+    {
+        internal Func<string, TProperty> ConversionFromString { get; set; }
+
+        internal Func<TProperty, string> ConversionToString { get; set; }
+
+        public bool CanConvertFrom(Type type)
+        {
+            return (type == typeof(string) && ConversionFromString != null) ||
+                   (type == typeof(TProperty) && ConversionToString != null);
+        }
+
+        public bool CanConvertTo(Type type)
+        {
+            return (type == typeof(string) && ConversionToString != null) ||
+                   (type == typeof(TProperty) && ConversionFromString != null);
+        }
+
+        public object ConvertFromString(string source, PropertyInfo targetProperty)
+        {
+            return ConversionFromString(source);
+        }
+
+        public string ConvertToString(object source, PropertyInfo sourceProperty)
+        {
+            return ConversionToString((TProperty)source);
+        }
+    }
+}

--- a/src/FlatFile.Core/FlatFile.Core.csproj
+++ b/src/FlatFile.Core/FlatFile.Core.csproj
@@ -100,7 +100,7 @@
     <Compile Include="Base\FlatFileEngine.cs" />
     <Compile Include="Base\LayoutBase.cs" />
     <Compile Include="Base\LayoutDescriptorBase.cs" />
-    <Compile Include="Base\LineBulderBase.cs" />
+    <Compile Include="Base\LineBuilderBase.cs" />
     <Compile Include="Base\LineParserBase.cs" />
     <Compile Include="Exceptions\ParseLineException.cs" />
     <Compile Include="Extensions\ExpressionExtensions.cs" />
@@ -117,7 +117,7 @@
     <Compile Include="ILayout.cs" />
     <Compile Include="ILayoutDescriptor.cs" />
     <Compile Include="ILineBuilderFactory.cs" />
-    <Compile Include="ILineBulder.cs" />
+    <Compile Include="ILineBuilder.cs" />
     <Compile Include="ILineParser.cs" />
     <Compile Include="ILineParserFactory.cs" />
     <Compile Include="ITypeConverter.cs" />

--- a/src/FlatFile.Core/FlatFile.Core.csproj
+++ b/src/FlatFile.Core/FlatFile.Core.csproj
@@ -102,6 +102,8 @@
     <Compile Include="Base\LayoutDescriptorBase.cs" />
     <Compile Include="Base\LineBuilderBase.cs" />
     <Compile Include="Base\LineParserBase.cs" />
+    <Compile Include="Base\TypeConverterBase.cs" />
+    <Compile Include="DelegatingTypeConverter.cs" />
     <Compile Include="Exceptions\ParseLineException.cs" />
     <Compile Include="Extensions\ExpressionExtensions.cs" />
     <Compile Include="Extensions\FieldsSettingsExtensions.cs" />

--- a/src/FlatFile.Core/IFieldSettingsConstructor.cs
+++ b/src/FlatFile.Core/IFieldSettingsConstructor.cs
@@ -1,11 +1,14 @@
 ﻿namespace FlatFile.Core
 {
     using FlatFile.Core.Base;
+    using System;
 
     public interface IFieldSettingsConstructor<out TConstructor> : IFieldSettingsContainer
         where TConstructor : IFieldSettingsConstructor<TConstructor>
     {
         TConstructor AllowNull(string nullValue);
         TConstructor WithTypeConverter<TConverter>() where TConverter : ITypeConverter;
+        TConstructor WithConversionFromString<TProperty>(Func<string, TProperty> conversion);
+        TConstructor WithConversionToString<TProperty>(Func<TProperty, string> conversion);
     }
 }

--- a/src/FlatFile.Core/ILineBuilder.cs
+++ b/src/FlatFile.Core/ILineBuilder.cs
@@ -1,6 +1,6 @@
 namespace FlatFile.Core
 {
-    public interface ILineBulder
+    public interface ILineBuilder
     {
         string BuildLine<T>(T entry);
     }

--- a/src/FlatFile.Core/ILineBuilderFactory.cs
+++ b/src/FlatFile.Core/ILineBuilderFactory.cs
@@ -5,7 +5,7 @@ namespace FlatFile.Core
     public interface ILineBuilderFactory<out TBuilder, in TLayout, TFieldSettings>
         where TFieldSettings : IFieldSettings   
         where TLayout : ILayoutDescriptor<TFieldSettings>
-        where TBuilder : ILineBulder
+        where TBuilder : ILineBuilder
     {
         TBuilder GetBuilder(TLayout layout);
     }

--- a/src/FlatFile.Core/ITypeConverter.cs
+++ b/src/FlatFile.Core/ITypeConverter.cs
@@ -1,6 +1,7 @@
 ﻿namespace FlatFile.Core
 {
     using System;
+    using System.Reflection;
 
     public interface ITypeConverter
     {
@@ -8,8 +9,8 @@
 
         bool CanConvertTo(Type type);
 
-        string ConvertToString(object source);
+        string ConvertToString(object source, PropertyInfo sourceProperty);
 
-        object ConvertFromString(string source);
+        object ConvertFromString(string source, PropertyInfo targetProperty);
     }
 }

--- a/src/FlatFile.Delimited/IDelimitedLineBuilder.cs
+++ b/src/FlatFile.Delimited/IDelimitedLineBuilder.cs
@@ -2,7 +2,7 @@
 {
     using FlatFile.Core;
 
-    public interface IDelimitedLineBuilder : ILineBulder
+    public interface IDelimitedLineBuilder : ILineBuilder
     {
     }
 }

--- a/src/FlatFile.Delimited/Implementation/DelimetedFileMultiEngine.cs
+++ b/src/FlatFile.Delimited/Implementation/DelimetedFileMultiEngine.cs
@@ -79,7 +79,7 @@ namespace FlatFile.Delimited.Implementation
         /// <value>The line builder.</value>
         /// <remarks>The <see cref="DelimitedFileMultiEngine"/> does not contain just a single line builder.</remarks>
         /// <exception cref="System.NotImplementedException"></exception>
-        protected override ILineBulder LineBuilder { get { throw new NotImplementedException(); } }
+        protected override ILineBuilder LineBuilder { get { throw new NotImplementedException(); } }
 
         /// <summary>
         /// Gets the line parser.

--- a/src/FlatFile.Delimited/Implementation/DelimitedFieldSettingsConstructor.cs
+++ b/src/FlatFile.Delimited/Implementation/DelimitedFieldSettingsConstructor.cs
@@ -1,5 +1,6 @@
 ﻿namespace FlatFile.Delimited.Implementation
 {
+    using System;
     using System.Reflection;
     using FlatFile.Core;
     using FlatFile.Core.Extensions;
@@ -22,6 +23,32 @@
         public IDelimitedFieldSettingsConstructor WithTypeConverter<TConverter>() where TConverter : ITypeConverter
         {
             this.TypeConverter = ReflectionHelper.CreateInstance<TConverter>(true);
+            return this;
+        }
+
+        public IDelimitedFieldSettingsConstructor WithConversionFromString<TProperty>(Func<string, TProperty> conversion)
+        {
+            if (TypeConverter == null)
+                TypeConverter = new DelegatingTypeConverter<TProperty>();
+
+            if (TypeConverter is DelegatingTypeConverter<TProperty>)
+                ((DelegatingTypeConverter<TProperty>)TypeConverter).ConversionFromString = conversion;
+            else
+                throw new InvalidOperationException("A type converter has already been explicitly set.");
+
+            return this;
+        }
+
+        public IDelimitedFieldSettingsConstructor WithConversionToString<TProperty>(Func<TProperty, string> conversion)
+        {
+            if (TypeConverter == null)
+                TypeConverter = new DelegatingTypeConverter<TProperty>();
+
+            if (TypeConverter is DelegatingTypeConverter<TProperty>)
+                ((DelegatingTypeConverter<TProperty>)TypeConverter).ConversionToString = conversion;
+            else
+                throw new InvalidOperationException("A type converter has already been explicitly set.");
+
             return this;
         }
 

--- a/src/FlatFile.Delimited/Implementation/DelimitedFileEngine.cs
+++ b/src/FlatFile.Delimited/Implementation/DelimitedFileEngine.cs
@@ -50,7 +50,7 @@ namespace FlatFile.Delimited.Implementation
         /// Gets the line builder.
         /// </summary>
         /// <value>The line builder.</value>
-        protected override ILineBulder LineBuilder
+        protected override ILineBuilder LineBuilder
         {
             get { return _builderFactory.GetBuilder(LayoutDescriptor); }
         }

--- a/src/FlatFile.Delimited/Implementation/DelimitedLineBuilder.cs
+++ b/src/FlatFile.Delimited/Implementation/DelimitedLineBuilder.cs
@@ -4,7 +4,7 @@
     using FlatFile.Core.Base;
 
     public class DelimitedLineBuilder :
-        LineBulderBase<IDelimitedLayoutDescriptor, IDelimitedFieldSettingsContainer>, 
+        LineBuilderBase<IDelimitedLayoutDescriptor, IDelimitedFieldSettingsContainer>, 
         IDelimitedLineBuilder
     {
         public DelimitedLineBuilder(IDelimitedLayoutDescriptor descriptor)

--- a/src/FlatFile.FixedLength/IFixedLengthLineBuilder.cs
+++ b/src/FlatFile.FixedLength/IFixedLengthLineBuilder.cs
@@ -2,7 +2,7 @@ namespace FlatFile.FixedLength
 {
     using FlatFile.Core;
 
-    public interface IFixedLengthLineBuilder : ILineBulder
+    public interface IFixedLengthLineBuilder : ILineBuilder
     {
     }
 }

--- a/src/FlatFile.FixedLength/Implementation/FixedFieldSettingsConstructor.cs
+++ b/src/FlatFile.FixedLength/Implementation/FixedFieldSettingsConstructor.cs
@@ -57,5 +57,31 @@ namespace FlatFile.FixedLength.Implementation
             this.TypeConverter = ReflectionHelper.CreateInstance<TConverter>(true);
             return this;
         }
+
+        public IFixedFieldSettingsConstructor WithConversionFromString<TProperty>(Func<string, TProperty> conversion)
+        {
+            if (TypeConverter == null)
+                TypeConverter = new DelegatingTypeConverter<TProperty>();
+
+            if (TypeConverter is DelegatingTypeConverter<TProperty>)
+                ((DelegatingTypeConverter<TProperty>)TypeConverter).ConversionFromString = conversion;
+            else
+                throw new InvalidOperationException("A type converter has already been explicitly set.");
+
+            return this;
+        }
+
+        public IFixedFieldSettingsConstructor WithConversionToString<TProperty>(Func<TProperty, string> conversion)
+        {
+            if (TypeConverter == null)
+                TypeConverter = new DelegatingTypeConverter<TProperty>();
+
+            if (TypeConverter is DelegatingTypeConverter<TProperty>)
+                ((DelegatingTypeConverter<TProperty>)TypeConverter).ConversionToString = conversion;
+            else
+                throw new InvalidOperationException("A type converter has already been explicitly set.");
+
+            return this;
+        }
     }
 }

--- a/src/FlatFile.FixedLength/Implementation/FixedLengthFileEngine.cs
+++ b/src/FlatFile.FixedLength/Implementation/FixedLengthFileEngine.cs
@@ -44,7 +44,7 @@ namespace FlatFile.FixedLength.Implementation
         /// Gets the line builder.
         /// </summary>
         /// <value>The line builder.</value>
-        protected override ILineBulder LineBuilder
+        protected override ILineBuilder LineBuilder
         {
             get { return lineBuilderFactory.GetBuilder(LayoutDescriptor); }
         }

--- a/src/FlatFile.FixedLength/Implementation/FixedLengthFileMultiEngine.cs
+++ b/src/FlatFile.FixedLength/Implementation/FixedLengthFileMultiEngine.cs
@@ -79,7 +79,7 @@ namespace FlatFile.FixedLength.Implementation
         /// <value>The line builder.</value>
         /// <remarks>The <see cref="FixedLengthFileMultiEngine"/> does not contain just a single line builder.</remarks>
         /// <exception cref="System.NotImplementedException"></exception>
-        protected override ILineBulder LineBuilder { get { throw new NotImplementedException(); } }
+        protected override ILineBuilder LineBuilder { get { throw new NotImplementedException(); } }
 
         /// <summary>
         /// Gets the line parser.

--- a/src/FlatFile.FixedLength/Implementation/FixedLengthLineBuilder.cs
+++ b/src/FlatFile.FixedLength/Implementation/FixedLengthLineBuilder.cs
@@ -5,7 +5,7 @@ namespace FlatFile.FixedLength.Implementation
     using FlatFile.Core.Base;
 
     public class FixedLengthLineBuilder :
-        LineBulderBase<ILayoutDescriptor<IFixedFieldSettingsContainer>, IFixedFieldSettingsContainer>,
+        LineBuilderBase<ILayoutDescriptor<IFixedFieldSettingsContainer>, IFixedFieldSettingsContainer>,
         IFixedLengthLineBuilder
     {
         public FixedLengthLineBuilder(ILayoutDescriptor<IFixedFieldSettingsContainer> descriptor)

--- a/src/FlatFile.Tests/Delimited/DelimitedAttributeMappingIntegrationTests.cs
+++ b/src/FlatFile.Tests/Delimited/DelimitedAttributeMappingIntegrationTests.cs
@@ -36,7 +36,7 @@ namespace FlatFile.Tests.Delimited
 		{
 			// a converter to convert "A" to "foo"
 			var converter = A.Fake<ITypeConverter>();
-			A.CallTo(() => converter.ConvertFromString("A")).Returns("foo");
+			A.CallTo(() => converter.ConvertFromString("A", A<PropertyInfo>.Ignored)).Returns("foo");
 			A.CallTo(() => converter.CanConvertFrom(typeof(string))).Returns(true);
 			A.CallTo(() => converter.CanConvertTo(typeof(string))).Returns(true);
 

--- a/src/FlatFile.Tests/Delimited/DelimitedLineBuilderTests.cs
+++ b/src/FlatFile.Tests/Delimited/DelimitedLineBuilderTests.cs
@@ -1,0 +1,68 @@
+﻿namespace FlatFile.Tests.Delimited
+{
+    using FlatFile.Core.Base;
+    using FlatFile.Delimited;
+    using FlatFile.Delimited.Implementation;
+    using FlatFile.Tests.Base.Entities;
+    using FluentAssertions;
+    using System;
+    using System.Globalization;
+    using System.Reflection;
+    using Xunit;
+
+    public class DelimitedLineBuilderTests
+    {
+        private readonly DelimitedLineBuilder builder;
+        private readonly IDelimitedLayout<TestObject> layout;
+
+        public DelimitedLineBuilderTests()
+        {
+            layout = new DelimitedLayout<TestObject>().WithDelimiter(",");
+
+            builder = new DelimitedLineBuilder(layout);
+        }
+
+        [Fact]
+        public void BuilderShouldUseTypeConverter()
+        {
+            layout.WithMember(o => o.Id, set => set.WithTypeConverter<IdHexConverter>());
+
+            var entry = new TestObject
+            {
+                Id = 48879
+            };
+
+            var line = builder.BuildLine(entry);
+
+            line.Should().Be("BEEF");
+        }
+
+        [Fact]
+        public void BuilderShouldUseConversionFunction()
+        {
+            layout.WithMember(o => o.Id, set => set.WithConversionToString((int id) => id.ToString("X")));
+
+            var entry = new TestObject
+            {
+                Id = 48879
+            };
+
+            var line = builder.BuildLine(entry);
+
+            line.Should().Be("BEEF");
+        }
+
+        class IdHexConverter : TypeConverterBase<int>
+        {
+            protected override int ConvertFrom(string source, PropertyInfo targetProperty)
+            {
+                return Int32.Parse(source, NumberStyles.AllowHexSpecifier);
+            }
+
+            protected override string ConvertTo(int source, PropertyInfo sourceProperty)
+            {
+                return source.ToString("X");
+            }
+        }
+    }
+}

--- a/src/FlatFile.Tests/Delimited/DelimitedLineParserTests.cs
+++ b/src/FlatFile.Tests/Delimited/DelimitedLineParserTests.cs
@@ -1,0 +1,60 @@
+﻿namespace FlatFile.Tests.Delimited
+{
+    using FlatFile.Core.Base;
+    using FlatFile.Delimited;
+    using FlatFile.Delimited.Implementation;
+    using FlatFile.Tests.Base.Entities;
+    using FluentAssertions;
+    using System;
+    using System.Globalization;
+    using System.Reflection;
+    using Xunit;
+
+    public class DelimitedLineParserTests
+    {
+        private readonly DelimitedLineParser parser;
+        private readonly IDelimitedLayout<TestObject> layout;
+
+        public DelimitedLineParserTests()
+        {
+            layout = new DelimitedLayout<TestObject>().WithDelimiter(",");
+
+            parser = new DelimitedLineParser(layout);
+        }
+
+        [Fact]
+        public void ParserShouldUseTypeConverter()
+        {
+            layout.WithMember(o => o.Id, set => set.WithTypeConverter<IdHexConverter>());
+
+            var entry = new TestObject();
+            var parsedEntity = parser.ParseLine("BEEF", entry);
+
+            parsedEntity.Id.Should().Be(48879);
+        }
+
+        [Fact]
+        public void ParserShouldUseConversionFunction()
+        {
+            layout.WithMember(o => o.Id, set => set.WithConversionFromString(s => Int32.Parse(s, NumberStyles.AllowHexSpecifier)));
+
+            var entry = new TestObject();
+            var parsedEntity = parser.ParseLine("BEEF", entry);
+
+            parsedEntity.Id.Should().Be(48879);
+        }
+
+        class IdHexConverter : TypeConverterBase<int>
+        {
+            protected override int ConvertFrom(string source, PropertyInfo targetProperty)
+            {
+                return Int32.Parse(source, NumberStyles.AllowHexSpecifier);
+            }
+
+            protected override string ConvertTo(int source, PropertyInfo sourceProperty)
+            {
+                return source.ToString("X");
+            }
+        }
+    }
+}

--- a/src/FlatFile.Tests/FixedLength/FixedLengthLineBuilderTests.cs
+++ b/src/FlatFile.Tests/FixedLength/FixedLengthLineBuilderTests.cs
@@ -1,0 +1,68 @@
+﻿namespace FlatFile.Tests.FixedLength
+{
+    using FlatFile.Core.Base;
+    using FlatFile.FixedLength;
+    using FlatFile.FixedLength.Implementation;
+    using FlatFile.Tests.Base.Entities;
+    using FluentAssertions;
+    using System;
+    using System.Globalization;
+    using System.Reflection;
+    using Xunit;
+
+    public class FixedLengthLineBuilderTests
+    {
+        private readonly FixedLengthLineBuilder builder;
+        private readonly IFixedLayout<TestObject> layout;
+
+        public FixedLengthLineBuilderTests()
+        {
+            layout = new FixedLayout<TestObject>();
+
+            builder = new FixedLengthLineBuilder(layout);
+        }
+
+        [Fact]
+        public void BuilderShouldUseTypeConverter()
+        {
+            layout.WithMember(o => o.Id, set => set.WithLength(4).WithTypeConverter<IdHexConverter>());
+
+            var entry = new TestObject
+            {
+                Id = 48879
+            };
+
+            var line = builder.BuildLine(entry);
+
+            line.Should().Be("BEEF");
+        }
+
+        [Fact]
+        public void BuilderShouldUseConversionFunction()
+        {
+            layout.WithMember(o => o.Id, set => set.WithLength(4).WithConversionToString((int id) => id.ToString("X")));
+
+            var entry = new TestObject
+            {
+                Id = 48879
+            };
+
+            var line = builder.BuildLine(entry);
+
+            line.Should().Be("BEEF");
+        }
+
+        class IdHexConverter : TypeConverterBase<int>
+        {
+            protected override int ConvertFrom(string source, PropertyInfo targetProperty)
+            {
+                return Int32.Parse(source, NumberStyles.AllowHexSpecifier);
+            }
+
+            protected override string ConvertTo(int source, PropertyInfo sourceProperty)
+            {
+                return source.ToString("X");
+            }
+        }
+    }
+}

--- a/src/FlatFile.Tests/FlatFile.Tests.csproj
+++ b/src/FlatFile.Tests/FlatFile.Tests.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -13,6 +14,8 @@
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -79,11 +82,14 @@
     <Compile Include="Delimited\DelimitedAttributeMappingIntegrationTests.cs" />
     <Compile Include="Delimited\DelimitedIntegrationTests.cs" />
     <Compile Include="Delimited\DelimitedLayoutTests.cs" />
+    <Compile Include="Delimited\DelimitedLineBuilderTests.cs" />
+    <Compile Include="Delimited\DelimitedLineParserTests.cs" />
     <Compile Include="Delimited\DelimitedMultiEngineTests.cs" />
     <Compile Include="Delimited\DelimitedWithHeaderIntegrationTests.cs" />
     <Compile Include="FixedLength\FixedLayoutTests.cs" />
     <Compile Include="FixedLength\FixedLengthAttributeMappingIntegrationTests.cs" />
     <Compile Include="FixedLength\FixedLengthIntegrationTests.cs" />
+    <Compile Include="FixedLength\FixedLengthLineBuilderTests.cs" />
     <Compile Include="FixedLength\FixedLengthLineParserTests.cs" />
     <Compile Include="FixedLength\FixedLengthMasterDetailTests.cs" />
     <Compile Include="FixedLength\FixedLengthMultiEngineTests.cs" />
@@ -138,6 +144,12 @@
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.runner.visualstudio.2.1.0\build\net20\xunit.runner.visualstudio.props'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/FlatFile.Tests/packages.config
+++ b/src/FlatFile.Tests/packages.config
@@ -11,4 +11,5 @@
   <package id="xunit.extensibility.core" version="2.1.0" targetFramework="net45" />
   <package id="xunit.extensibility.execution" version="2.1.0" targetFramework="net45" />
   <package id="xunit.runner.console" version="2.1.0" targetFramework="net45" />
+  <package id="xunit.runner.visualstudio" version="2.1.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
This pull request implements a series of changes intended to enhance and improve the use of type converters. It partially addresses #68, but does not include line or column numbers. It also fixes #66.

- `ITypeConverter`'s conversion methods now take the `PropertyInfo` of the class property being converted to or from. This provides type converters with much needed context and metadata. For example, custom attributes could be applied to properties and then retrieved during conversion. Unfortunately, this is a major breaking api change. I am open to suggestions about ways to ease or avoid this. An entirely new interface could be added, but I did not pursue that.
#68 specifies "Destination Object Type (not the property)", but `PropertyInfo` provides access to this information and more.

- When writing files, `ITypeConverter.ConvertToString` was not being used at all, relying simply on `ToString()`. `LineBuilderBase` has been modified to use a type converter if provided.

- Finally, two additional methods were added to `IFieldSettingsConstructor`: `WithConversionFromString` and `WithConversionToString`. These both take lambda functions, one converting to a property's target value from a string when reading, and the other converting from a property's value to a string when writing. These are simpler to use than implementing a fully-fledged type converter, but the existing type conversion machinery is still used underneath. 
I tried to get the inferred property type to flow from the `WithMember` call, but after several aborted attempts, I gave up. The interaction of inherited interfaces and generic type arguments is fairly complex, and I could not find a way to make it work.