### PR TITLE
Modernize to .NET 8: add SDK-style projects, CI and NuGet publish workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,3 +25,7 @@ jobs:
           dotnet build src/FlatFile.FixedLength.Modern/FlatFile.FixedLength.Modern.csproj -c Release
           dotnet build src/FlatFile.Delimited.Attributes.Modern/FlatFile.Delimited.Attributes.Modern.csproj -c Release
           dotnet build src/FlatFile.FixedLength.Attributes.Modern/FlatFile.FixedLength.Attributes.Modern.csproj -c Release
+          dotnet build tests/FlatFile.Modern.Tests/FlatFile.Modern.Tests.csproj -c Release
+
+      - name: Run modern test suite
+        run: dotnet test tests/FlatFile.Modern.Tests/FlatFile.Modern.Tests.csproj -c Release --no-build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+    branches: [ master, main, dev ]
+  pull_request:
+
+jobs:
+  build-dotnet8:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Build modern SDK-style projects (v2)
+        run: |
+          dotnet build src/FlatFile.Core.Modern/FlatFile.Core.Modern.csproj -c Release
+          dotnet build src/FlatFile.Core.Attributes.Modern/FlatFile.Core.Attributes.Modern.csproj -c Release
+          dotnet build src/FlatFile.Delimited.Modern/FlatFile.Delimited.Modern.csproj -c Release
+          dotnet build src/FlatFile.FixedLength.Modern/FlatFile.FixedLength.Modern.csproj -c Release
+          dotnet build src/FlatFile.Delimited.Attributes.Modern/FlatFile.Delimited.Attributes.Modern.csproj -c Release
+          dotnet build src/FlatFile.FixedLength.Attributes.Modern/FlatFile.FixedLength.Attributes.Modern.csproj -c Release

--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -1,0 +1,48 @@
+name: Publish NuGet (v2)
+
+on:
+  push:
+    branches: [ master ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    env:
+      NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+      PACKAGE_VERSION: 2.0.${{ github.run_number }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Validate NuGet API key is configured
+        run: |
+          if [ -z "$NUGET_API_KEY" ]; then
+            echo "NUGET_API_KEY secret is not configured." >&2
+            exit 1
+          fi
+
+      - name: Pack v2 packages
+        run: |
+          mkdir -p artifacts/packages
+          dotnet pack src/FlatFile.Core.Modern/FlatFile.Core.Modern.csproj -c Release -o artifacts/packages /p:Version=$PACKAGE_VERSION
+          dotnet pack src/FlatFile.Core.Attributes.Modern/FlatFile.Core.Attributes.Modern.csproj -c Release -o artifacts/packages /p:Version=$PACKAGE_VERSION
+          dotnet pack src/FlatFile.Delimited.Modern/FlatFile.Delimited.Modern.csproj -c Release -o artifacts/packages /p:Version=$PACKAGE_VERSION
+          dotnet pack src/FlatFile.FixedLength.Modern/FlatFile.FixedLength.Modern.csproj -c Release -o artifacts/packages /p:Version=$PACKAGE_VERSION
+          dotnet pack src/FlatFile.Delimited.Attributes.Modern/FlatFile.Delimited.Attributes.Modern.csproj -c Release -o artifacts/packages /p:Version=$PACKAGE_VERSION
+          dotnet pack src/FlatFile.FixedLength.Attributes.Modern/FlatFile.FixedLength.Attributes.Modern.csproj -c Release -o artifacts/packages /p:Version=$PACKAGE_VERSION
+
+      - name: Publish packages to NuGet
+        run: |
+          dotnet nuget push "artifacts/packages/*.nupkg" \
+            --api-key "$NUGET_API_KEY" \
+            --source https://api.nuget.org/v3/index.json \
+            --skip-duplicate

--- a/README.md
+++ b/README.md
@@ -4,6 +4,44 @@ FlatFile
 
 FlatFile is a library to work with flat files (work up-to 100 times faster then [FileHelpers](https://www.nuget.org/packages/FileHelpers/2.0.0))
 
+
+## Modernization status
+
+- 🚨 **v2 breaking change**: dropped legacy .NET Framework targets (`net35`-`net48`) and old build pipeline.
+- ✅ Modernized runtime support to **.NET 8** only via SDK-style projects.
+- ✅ CI now builds modern projects with `dotnet build` on GitHub Actions.
+
+### Modern .NET support
+
+Active projects:
+
+- `src/FlatFile.Core.Modern`
+- `src/FlatFile.Core.Attributes.Modern`
+- `src/FlatFile.Delimited.Modern`
+- `src/FlatFile.FixedLength.Modern`
+- `src/FlatFile.Delimited.Attributes.Modern`
+- `src/FlatFile.FixedLength.Attributes.Modern`
+
+All of them target `net8.0` and carry package/assembly version `2.0.0`.
+
+### Runtime enhancements (v2)
+
+Recent runtime-focused updates for modern .NET:
+
+- Faster reflection activation path via compiled constructor delegates and concurrent caches.
+- Improved string-to-type conversion using cached `TypeConverter` instances and invariant-culture conversion semantics.
+- Reduced allocations in parsing paths (for example, char-based trim overloads and span-based quote detection in delimited parser).
+
+### NuGet publishing from GitHub
+
+When changes are merged to `master`, GitHub Actions can publish v2 packages automatically using `.github/workflows/publish-nuget.yml`.
+
+Required repository secret:
+
+- `NUGET_API_KEY`: NuGet.org API key with push permission for FlatFile packages.
+
+The publish workflow packs all `*.Modern` projects and pushes resulting `.nupkg` files to NuGet (`--skip-duplicate`).
+
 ### Installing FlatFile
 
 #### Installing all packages

--- a/assets/psake-common.ps1
+++ b/assets/psake-common.ps1
@@ -20,8 +20,15 @@ Properties {
     ### Project information
     $solution_path = "$src_dir\$solution"
 	$sharedAssemblyInfo = "$src_dir\SharedAssemblyInfo.cs"
-    $config = "Release"    
-	$frameworks = @("NET35", "NET40", "NET45")
+    $config = "Release"
+    $modern_projects = @(
+        "$src_dir\FlatFile.Core.Modern\FlatFile.Core.Modern.csproj",
+        "$src_dir\FlatFile.Core.Attributes.Modern\FlatFile.Core.Attributes.Modern.csproj",
+        "$src_dir\FlatFile.Delimited.Modern\FlatFile.Delimited.Modern.csproj",
+        "$src_dir\FlatFile.FixedLength.Modern\FlatFile.FixedLength.Modern.csproj",
+        "$src_dir\FlatFile.Delimited.Attributes.Modern\FlatFile.Delimited.Attributes.Modern.csproj",
+        "$src_dir\FlatFile.FixedLength.Attributes.Modern\FlatFile.FixedLength.Attributes.Modern.csproj"
+    )
     
     ### Files
     $releaseNotes = "$base_dir\ChangeLog.md"
@@ -29,34 +36,27 @@ Properties {
 
 ## Tasks
 
-Task Restore -Description "Restore NuGet packages for solution." {
-    "Restoring NuGet packages for '$solution_path'..."
-    Exec { .$nuget restore $solution_path }
+Task Restore -Description "Restore .NET packages for modern projects." {
+    foreach ($project in $modern_projects) {
+        "Restoring '$project'..."
+        Exec { dotnet restore $project }
+    }
 }
 
 Task Clean -Description "Clean up build and project folders." {
     Clean-Directory $build_dir
 
-    if ($solution) {
-        "Cleaning up '$solution'..."
-        
-		foreach ($framework in $frameworks) {
-			Exec { msbuild $solution_path /target:Clean /nologo /verbosity:minimal /p:Framework=$framework}
-		}
+    foreach ($project in $modern_projects) {
+        "Cleaning '$project'..."
+        Exec { dotnet clean $project -c $config }
     }
 }
 
-Task Compile -Depends Clean, Restore -Description "Compile all the projects in a solution." {
-    "Compiling '$solution'..."
-
-    $extra = $null
-    if ($appVeyor) {
-        $extra = "/logger:C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
+Task Compile -Depends Clean, Restore -Description "Compile all modern SDK-style projects." {
+    foreach ($project in $modern_projects) {
+        "Compiling '$project'..."
+        Exec { dotnet build $project -c $config --no-restore }
     }
-
-	foreach ($framework in $frameworks) {
-		Exec { msbuild $solution_path /p:"Configuration=$config;Framework=$framework" /nologo /verbosity:minimal $extra }
-	}
 }
 
 ### Pack functions

--- a/docs/modernization-plan.md
+++ b/docs/modernization-plan.md
@@ -32,3 +32,9 @@ A major-version reset enables simpler tooling, faster builds, and a clear suppor
 - Replaced reflection activation lock+`DynamicInvoke` path with concurrent cached compiled factories.
 - Updated conversion pipeline to use converter caching and invariant-culture conversion semantics.
 - Applied small parser allocation improvements (`TrimStart/TrimEnd(char)`, span-based quote prefix checks).
+
+
+## Modern tests
+
+- Added `tests/FlatFile.Modern.Tests` (xUnit, net8.0).
+- CI now runs `dotnet test` for the modern test suite.

--- a/docs/modernization-plan.md
+++ b/docs/modernization-plan.md
@@ -1,0 +1,34 @@
+# FlatFile modernization plan
+
+## Current direction (v2)
+
+This repository now follows a **modern-only** strategy:
+
+1. Legacy .NET Framework build matrix was removed from CI.
+2. SDK-style projects under `*.Modern` are the active build path.
+3. Active target is `net8.0` with version `2.0.0` (breaking major release).
+
+## Why
+
+The previous mixed strategy (legacy + modern) produced unstable CI and unnecessary maintenance overhead.
+A major-version reset enables simpler tooling, faster builds, and a clear support policy.
+
+## Next steps
+
+- Publish v2 packages from modern projects (`dotnet pack`).
+- Add analyzers and nullable annotations incrementally.
+- Add dedicated test projects targeting `net8.0`.
+
+
+## CI/CD publishing
+
+- `.github/workflows/publish-nuget.yml` publishes NuGet packages on pushes to `master`.
+- Configure repository secret `NUGET_API_KEY` before enabling release merges.
+- Package versions are generated as `2.0.<run_number>` in CI.
+
+
+## Implemented performance updates
+
+- Replaced reflection activation lock+`DynamicInvoke` path with concurrent cached compiled factories.
+- Updated conversion pipeline to use converter caching and invariant-culture conversion semantics.
+- Applied small parser allocation improvements (`TrimStart/TrimEnd(char)`, span-based quote prefix checks).

--- a/docs/modernization-plan.md
+++ b/docs/modernization-plan.md
@@ -38,3 +38,11 @@ A major-version reset enables simpler tooling, faster builds, and a clear suppor
 
 - Added `tests/FlatFile.Modern.Tests` (xUnit, net8.0).
 - CI now runs `dotnet test` for the modern test suite.
+
+
+## Span/Memory guidelines used
+
+- Use `ReadOnlySpan<char>` for scanning/tokenization (delimiter/quote detection) where data remains in-memory and does not need ownership transfer.
+- Use `Memory<T>` only when data must survive async boundaries; prefer `Span<T>`/`ReadOnlySpan<T>` in synchronous hot paths.
+- Avoid premature `Substring`/`string.Format` allocations in line build/parse loops.
+- Keep API compatibility: introduce span optimizations internally first, then expose span APIs in a dedicated v2+ surface when needed.

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,0 +1,17 @@
+<Project>
+  <PropertyGroup Condition="$([System.String]::Copy('$(MSBuildProjectName)').Contains('.Modern'))">
+    <IsPackable>true</IsPackable>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <Authors>forcewake</Authors>
+    <Company>Pavel Nasovich</Company>
+    <Description>FlatFile library for high-performance fixed-length and delimited file processing.</Description>
+    <PackageProjectUrl>https://github.com/forcewake/FlatFile</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/forcewake/FlatFile</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+  </PropertyGroup>
+
+  <ItemGroup Condition="$([System.String]::Copy('$(MSBuildProjectName)').Contains('.Modern'))">
+    <None Include="$(MSBuildThisFileDirectory)..\README.md" Pack="true" PackagePath="\" Link="README.md" />
+  </ItemGroup>
+</Project>

--- a/src/FlatFile.Benchmark/FlatFile.Benchmark.csproj
+++ b/src/FlatFile.Benchmark/FlatFile.Benchmark.csproj
@@ -31,6 +31,63 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+
+
+  <PropertyGroup Condition=" '$(Framework)' == 'NET451' ">
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Framework)' == 'NET452' ">
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Framework)' == 'NET46' ">
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Framework)' == 'NET461' ">
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Framework)' == 'NET462' ">
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Framework)' == 'NET47' ">
+    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Framework)' == 'NET471' ">
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Framework)' == 'NET472' ">
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Framework)' == 'NET48' And '$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\$(Configuration)\$(Framework)\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Framework)' == 'NET48' And '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\$(Configuration)\$(Framework)\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\$(Configuration)\$(Framework)\FlatFile.Benchmark.XML</DocumentationFile>
+  </PropertyGroup>
+
   <ItemGroup>
     <Reference Include="BenchmarkIt">
       <HintPath>..\packages\Benchmark.It.1.2.0\lib\BenchmarkIt.dll</HintPath>

--- a/src/FlatFile.Core.Attributes.Modern/FlatFile.Core.Attributes.Modern.csproj
+++ b/src/FlatFile.Core.Attributes.Modern/FlatFile.Core.Attributes.Modern.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <RootNamespace>FlatFile.Core.Attributes</RootNamespace>
+    <AssemblyName>FlatFile.Core.Attributes</AssemblyName>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <LangVersion>latest</LangVersion>
+    <Nullable>disable</Nullable>
+    <Deterministic>true</Deterministic>
+    <Version>2.0.0</Version>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+    <FileVersion>2.0.0.0</FileVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="../FlatFile.Core.Attributes/**/*.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../FlatFile.Core.Modern/FlatFile.Core.Modern.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/FlatFile.Core.Attributes/FlatFile.Core.Attributes.csproj
+++ b/src/FlatFile.Core.Attributes/FlatFile.Core.Attributes.csproj
@@ -86,6 +86,63 @@
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\$(Configuration)\$(Framework)\$(AssemblyName).XML</DocumentationFile>
   </PropertyGroup>
+
+
+  <PropertyGroup Condition=" '$(Framework)' == 'NET451' ">
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Framework)' == 'NET452' ">
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Framework)' == 'NET46' ">
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Framework)' == 'NET461' ">
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Framework)' == 'NET462' ">
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Framework)' == 'NET47' ">
+    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Framework)' == 'NET471' ">
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Framework)' == 'NET472' ">
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Framework)' == 'NET48' And '$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\$(Configuration)\$(Framework)\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Framework)' == 'NET48' And '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\$(Configuration)\$(Framework)\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\$(Configuration)\$(Framework)\FlatFile.Core.Attributes.XML</DocumentationFile>
+  </PropertyGroup>
+
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/FlatFile.Core.Modern/FlatFile.Core.Modern.csproj
+++ b/src/FlatFile.Core.Modern/FlatFile.Core.Modern.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <RootNamespace>FlatFile.Core</RootNamespace>
+    <AssemblyName>FlatFile.Core</AssemblyName>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <LangVersion>latest</LangVersion>
+    <Nullable>disable</Nullable>
+    <Deterministic>true</Deterministic>
+    <Version>2.0.0</Version>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+    <FileVersion>2.0.0.0</FileVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="../FlatFile.Core/**/*.cs" />
+  </ItemGroup>
+</Project>

--- a/src/FlatFile.Core/Base/FlatFileEngine.cs
+++ b/src/FlatFile.Core/Base/FlatFileEngine.cs
@@ -56,7 +56,8 @@ namespace FlatFile.Core.Base
         /// <exception cref="ParseLineException">Impossible to parse line</exception>
         public virtual IEnumerable<TEntity> Read<TEntity>(Stream stream) where TEntity : class, new()
         {
-            var reader = new StreamReader(stream);
+            using (var reader = new StreamReader(stream))
+            {
             string line;
             int lineNumber = 0;
 
@@ -65,37 +66,38 @@ namespace FlatFile.Core.Base
                 ProcessHeader(reader);
             }
 
-            while ((line = reader.ReadLine()) != null)
-            {
-                if (string.IsNullOrEmpty(line) || string.IsNullOrEmpty(line.Trim())) continue;
-                
-                bool ignoreEntry = false;
-                var entry = new TEntity();
-                try
+                while ((line = reader.ReadLine()) != null)
                 {
-                    if (!TryParseLine(line, lineNumber++, ref entry))
+                    if (string.IsNullOrWhiteSpace(line)) continue;
+
+                    bool ignoreEntry = false;
+                    var entry = new TEntity();
+                    try
                     {
-                        throw new ParseLineException("Impossible to parse line", line, lineNumber);
+                        if (!TryParseLine(line, lineNumber++, ref entry))
+                        {
+                            throw new ParseLineException("Impossible to parse line", line, lineNumber);
+                        }
                     }
-                }
-                catch (Exception ex)
-                {
-                    if (_handleEntryReadError == null)
+                    catch (Exception ex)
                     {
-                        throw;
+                        if (_handleEntryReadError == null)
+                        {
+                            throw;
+                        }
+
+                        if (!_handleEntryReadError(line, ex))
+                        {
+                            throw;
+                        }
+
+                        ignoreEntry = true;
                     }
 
-                    if (!_handleEntryReadError(line, ex))
+                    if (!ignoreEntry)
                     {
-                        throw;
+                        yield return entry;
                     }
-
-                    ignoreEntry = true;
-                }
-
-                if (!ignoreEntry)
-                {
-                    yield return entry;
                 }
             }
         }
@@ -146,22 +148,23 @@ namespace FlatFile.Core.Base
         /// <param name="entries">The entries.</param>
         public virtual void Write<TEntity>(Stream stream, IEnumerable<TEntity> entries) where TEntity : class, new()
         {
-            TextWriter writer = new StreamWriter(stream);
-
-            this.WriteHeader(writer);
-
-            int lineNumber = 0;
-
-            foreach (var entry in entries)
+            using (TextWriter writer = new StreamWriter(stream))
             {
-                this.WriteEntry(writer, lineNumber, entry);
+                this.WriteHeader(writer);
 
-                lineNumber += 1;
+                int lineNumber = 0;
+
+                foreach (var entry in entries)
+                {
+                    this.WriteEntry(writer, lineNumber, entry);
+
+                    lineNumber += 1;
+                }
+
+                this.WriteFooter(writer);
+
+                writer.Flush();
             }
-
-            this.WriteFooter(writer);
-
-            writer.Flush();
         }
 
         /// <summary>

--- a/src/FlatFile.Core/Exceptions/ParseLineException.cs
+++ b/src/FlatFile.Core/Exceptions/ParseLineException.cs
@@ -29,11 +29,13 @@
         public int LineNumber { get; private set; }
         public string Line { get; private set; }
 
+#pragma warning disable SYSLIB0051
         protected ParseLineException(SerializationInfo info, StreamingContext context, string line, int lineNumber)
             : base(info, context)
         {
             Line = line;
             LineNumber = lineNumber;
         }
+#pragma warning restore SYSLIB0051
     }
 }

--- a/src/FlatFile.Core/Extensions/PropertyAccessorCache.cs
+++ b/src/FlatFile.Core/Extensions/PropertyAccessorCache.cs
@@ -1,0 +1,53 @@
+namespace FlatFile.Core.Extensions
+{
+    using System;
+    using System.Collections.Concurrent;
+    using System.Linq.Expressions;
+    using System.Reflection;
+
+    internal static class PropertyAccessorCache
+    {
+        private static readonly ConcurrentDictionary<PropertyInfo, Func<object, object>> GetterCache =
+            new ConcurrentDictionary<PropertyInfo, Func<object, object>>();
+
+        private static readonly ConcurrentDictionary<PropertyInfo, Action<object, object>> SetterCache =
+            new ConcurrentDictionary<PropertyInfo, Action<object, object>>();
+
+        public static object GetValue(PropertyInfo propertyInfo, object target)
+        {
+            var getter = GetterCache.GetOrAdd(propertyInfo, BuildGetter);
+            return getter(target);
+        }
+
+        public static void SetValue(PropertyInfo propertyInfo, object target, object value)
+        {
+            var setter = SetterCache.GetOrAdd(propertyInfo, BuildSetter);
+            setter(target, value);
+        }
+
+        private static Func<object, object> BuildGetter(PropertyInfo propertyInfo)
+        {
+            var target = Expression.Parameter(typeof(object), "target");
+            var castTarget = Expression.Convert(target, propertyInfo.DeclaringType);
+            var property = Expression.Property(castTarget, propertyInfo);
+            var castResult = Expression.Convert(property, typeof(object));
+            return Expression.Lambda<Func<object, object>>(castResult, target).Compile();
+        }
+
+        private static Action<object, object> BuildSetter(PropertyInfo propertyInfo)
+        {
+            if (!propertyInfo.CanWrite)
+            {
+                return (target, value) => { };
+            }
+
+            var target = Expression.Parameter(typeof(object), "target");
+            var value = Expression.Parameter(typeof(object), "value");
+            var castTarget = Expression.Convert(target, propertyInfo.DeclaringType);
+            var castValue = Expression.Convert(value, propertyInfo.PropertyType);
+            var property = Expression.Property(castTarget, propertyInfo);
+            var assign = Expression.Assign(property, castValue);
+            return Expression.Lambda<Action<object, object>>(assign, target, value).Compile();
+        }
+    }
+}

--- a/src/FlatFile.Core/Extensions/ReflectionHelper.cs
+++ b/src/FlatFile.Core/Extensions/ReflectionHelper.cs
@@ -1,87 +1,92 @@
-﻿using System.Linq;
+﻿using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Linq.Expressions;
 using System.Reflection;
 
 namespace FlatFile.Core.Extensions
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq.Expressions;
-
     /// <summary>
     /// Class ReflectionHelper.
     /// </summary>
     public static class ReflectionHelper
     {
-        static readonly object CacheLock = new object();
-        static readonly Dictionary<ConstructorInfo, Delegate> Cache = new Dictionary<ConstructorInfo, Delegate>();
+        private static readonly ConcurrentDictionary<ConstructorInfo, Func<object>> NoArgCache = new ConcurrentDictionary<ConstructorInfo, Func<object>>();
+        private static readonly ConcurrentDictionary<ConstructorInfo, Func<object[], object>> ArgCache = new ConcurrentDictionary<ConstructorInfo, Func<object[], object>>();
 
         /// <summary>
         /// Creates an instance of type <typeparamref name="T"/> using the default constructor.
         /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="cached">if set to <c>true</c> [cached].</param>
-        /// <returns>T.</returns>
-        public static T CreateInstance<T>(bool cached = false) { return (T) CreateInstance(typeof (T), cached); }
+        public static T CreateInstance<T>(bool cached = false)
+        {
+            return (T)CreateInstance(typeof(T), cached);
+        }
 
         /// <summary>
         /// Creates an instance of type <paramref name="targetType"/> using the default constructor.
         /// </summary>
-        /// <param name="targetType">Type of the target.</param>
-        /// <param name="cached">if set to <c>true</c> [cached].</param>
-        /// <returns>System.Object.</returns>
         public static object CreateInstance(Type targetType, bool cached = false)
         {
             if (targetType == null) return null;
 
             var ctorInfo = targetType.GetConstructor(Type.EmptyTypes);
-
             return CreateInstance(ctorInfo, cached);
         }
 
         /// <summary>
         /// Creates an instance of type <paramref name="targetType"/> using the specified constructor parameters.
         /// </summary>
-        /// <param name="targetType">Type of the target.</param>
-        /// <param name="cached">if set to <c>true</c> [cached].</param>
-        /// <param name="parameters">The constructor arguments.</param>
-        /// <returns>System.Object.</returns>
         public static object CreateInstance(Type targetType, bool cached = false, params object[] parameters)
         {
             if (targetType == null) return null;
             if (parameters == null || !parameters.Any()) return CreateInstance(targetType, cached);
 
             var ctorInfo = targetType.GetConstructor(parameters.Select(a => a.GetType()).ToArray());
-
             return CreateInstance(ctorInfo, cached, parameters);
         }
 
-        static object CreateInstance(ConstructorInfo ctorInfo, bool cached, object[] parameters = null)
+        private static object CreateInstance(ConstructorInfo ctorInfo, bool cached, object[] parameters = null)
         {
             if (ctorInfo == null) return null;
+
             var hasArguments = parameters != null && parameters.Any();
-
-            Delegate ctor;
-            lock (CacheLock)
+            if (!cached)
             {
-                if (!Cache.TryGetValue(ctorInfo, out ctor) || !cached)
-                {
-                    if (hasArguments)
-                    {
-                        var ctorArgs = ctorInfo.GetParameters().Select((param, index) => Expression.Parameter(param.ParameterType, String.Format("Param{0}", index))).ToArray();
-                        // ReSharper disable once CoVariantArrayConversion
-                        ctor = Expression.Lambda(Expression.New(ctorInfo, ctorArgs), ctorArgs).Compile();
-                    }
-                    else
-                    {
-                        ctor = Expression.Lambda(Expression.New(ctorInfo)).Compile();
-                    }
-                }
-
-                if (cached) CacheCtor(ctorInfo, ctor);
+                return ctorInfo.Invoke(parameters);
             }
-            return hasArguments ? ctor.DynamicInvoke(parameters) : ctor.DynamicInvoke();
+
+            if (!hasArguments)
+            {
+                var factory = NoArgCache.GetOrAdd(ctorInfo, BuildNoArgFactory);
+                return factory();
+            }
+
+            var argFactory = ArgCache.GetOrAdd(ctorInfo, BuildArgFactory);
+            return argFactory(parameters);
         }
 
-        static void CacheCtor(ConstructorInfo key, Delegate ctor) { if (!Cache.ContainsKey(key)) Cache.Add(key, ctor); }
+        private static Func<object> BuildNoArgFactory(ConstructorInfo ctorInfo)
+        {
+            var ctorCall = Expression.New(ctorInfo);
+            var cast = Expression.Convert(ctorCall, typeof(object));
+            return Expression.Lambda<Func<object>>(cast).Compile();
+        }
+
+        private static Func<object[], object> BuildArgFactory(ConstructorInfo ctorInfo)
+        {
+            var argsParameter = Expression.Parameter(typeof(object[]), "args");
+            var ctorParameters = ctorInfo.GetParameters();
+
+            var arguments = ctorParameters
+                .Select((parameter, index) =>
+                    Expression.Convert(
+                        Expression.ArrayIndex(argsParameter, Expression.Constant(index)),
+                        parameter.ParameterType))
+                .ToArray();
+
+            var ctorCall = Expression.New(ctorInfo, arguments);
+            var cast = Expression.Convert(ctorCall, typeof(object));
+            return Expression.Lambda<Func<object[], object>>(cast, argsParameter).Compile();
+        }
     }
 }

--- a/src/FlatFile.Core/Extensions/ReflectionHelper.cs
+++ b/src/FlatFile.Core/Extensions/ReflectionHelper.cs
@@ -39,7 +39,7 @@ namespace FlatFile.Core.Extensions
         public static object CreateInstance(Type targetType, bool cached = false, params object[] parameters)
         {
             if (targetType == null) return null;
-            if (parameters == null || !parameters.Any()) return CreateInstance(targetType, cached);
+            if (parameters == null || parameters.Length == 0) return CreateInstance(targetType, cached);
 
             var ctorInfo = targetType.GetConstructor(parameters.Select(a => a.GetType()).ToArray());
             return CreateInstance(ctorInfo, cached, parameters);
@@ -49,7 +49,7 @@ namespace FlatFile.Core.Extensions
         {
             if (ctorInfo == null) return null;
 
-            var hasArguments = parameters != null && parameters.Any();
+            var hasArguments = parameters != null && parameters.Length > 0;
             if (!cached)
             {
                 return ctorInfo.Invoke(parameters);

--- a/src/FlatFile.Core/Extensions/TypeChangeExtensions.cs
+++ b/src/FlatFile.Core/Extensions/TypeChangeExtensions.cs
@@ -29,6 +29,56 @@ namespace FlatFile.Core.Extensions
                 return Enum.Parse(underlyingType, input, true);
             }
 
+            if (underlyingType == typeof(string))
+            {
+                return input;
+            }
+
+            if (underlyingType == typeof(int))
+            {
+                return int.Parse(input, NumberStyles.Integer, CultureInfo.InvariantCulture);
+            }
+
+            if (underlyingType == typeof(long))
+            {
+                return long.Parse(input, NumberStyles.Integer, CultureInfo.InvariantCulture);
+            }
+
+            if (underlyingType == typeof(short))
+            {
+                return short.Parse(input, NumberStyles.Integer, CultureInfo.InvariantCulture);
+            }
+
+            if (underlyingType == typeof(decimal))
+            {
+                return decimal.Parse(input, NumberStyles.Number, CultureInfo.InvariantCulture);
+            }
+
+            if (underlyingType == typeof(double))
+            {
+                return double.Parse(input, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture);
+            }
+
+            if (underlyingType == typeof(float))
+            {
+                return float.Parse(input, NumberStyles.Float | NumberStyles.AllowThousands, CultureInfo.InvariantCulture);
+            }
+
+            if (underlyingType == typeof(bool))
+            {
+                return bool.Parse(input);
+            }
+
+            if (underlyingType == typeof(Guid))
+            {
+                return Guid.Parse(input);
+            }
+
+            if (underlyingType == typeof(DateTime))
+            {
+                return DateTime.Parse(input, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
+            }
+
             var converter = ConverterCache.GetOrAdd(underlyingType, TypeDescriptor.GetConverter);
             if (converter != null)
             {

--- a/src/FlatFile.Core/Extensions/TypeChangeExtensions.cs
+++ b/src/FlatFile.Core/Extensions/TypeChangeExtensions.cs
@@ -1,23 +1,54 @@
 namespace FlatFile.Core.Extensions
 {
     using System;
+    using System.Collections.Concurrent;
     using System.ComponentModel;
+    using System.Globalization;
 
     public static class TypeChangeExtensions
     {
+        private static readonly ConcurrentDictionary<Type, TypeConverter> ConverterCache = new ConcurrentDictionary<Type, TypeConverter>();
+
         public static object Convert(this string input, Type targetType)
         {
-            var converter = TypeDescriptor.GetConverter(targetType);
+            if (targetType == null)
+            {
+                throw new ArgumentNullException("targetType");
+            }
+
+            var underlyingType = Nullable.GetUnderlyingType(targetType) ?? targetType;
+            if (string.IsNullOrWhiteSpace(input))
+            {
+                return Nullable.GetUnderlyingType(targetType) != null
+                    ? null
+                    : targetType.GetDefaultValue();
+            }
+
+            if (underlyingType.IsEnum)
+            {
+                return Enum.Parse(underlyingType, input, true);
+            }
+
+            var converter = ConverterCache.GetOrAdd(underlyingType, TypeDescriptor.GetConverter);
             if (converter != null)
             {
-                return converter.ConvertFromString(input);
+                if (converter.CanConvertFrom(typeof(string)))
+                {
+                    return converter.ConvertFromInvariantString(input);
+                }
+
+                if (converter.CanConvertFrom(typeof(object)))
+                {
+                    return converter.ConvertFrom(null, CultureInfo.InvariantCulture, input);
+                }
             }
-            return targetType.GetDefaultValue();
+
+            return System.Convert.ChangeType(input, underlyingType, CultureInfo.InvariantCulture);
         }
 
         public static T Convert<T>(this string input)
         {
-            return (T) Convert(input, typeof (T));
+            return (T)Convert(input, typeof(T));
         }
     }
 }

--- a/src/FlatFile.Core/FlatFile.Core.csproj
+++ b/src/FlatFile.Core/FlatFile.Core.csproj
@@ -86,6 +86,63 @@
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\$(Configuration)\$(Framework)\FlatFile.Core.XML</DocumentationFile>
   </PropertyGroup>
+
+
+  <PropertyGroup Condition=" '$(Framework)' == 'NET451' ">
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Framework)' == 'NET452' ">
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Framework)' == 'NET46' ">
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Framework)' == 'NET461' ">
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Framework)' == 'NET462' ">
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Framework)' == 'NET47' ">
+    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Framework)' == 'NET471' ">
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Framework)' == 'NET472' ">
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Framework)' == 'NET48' And '$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\$(Configuration)\$(Framework)\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Framework)' == 'NET48' And '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\$(Configuration)\$(Framework)\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\$(Configuration)\$(Framework)\FlatFile.Core.XML</DocumentationFile>
+  </PropertyGroup>
+
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/FlatFile.Delimited.Attributes.Modern/FlatFile.Delimited.Attributes.Modern.csproj
+++ b/src/FlatFile.Delimited.Attributes.Modern/FlatFile.Delimited.Attributes.Modern.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <RootNamespace>FlatFile.Delimited.Attributes</RootNamespace>
+    <AssemblyName>FlatFile.Delimited.Attributes</AssemblyName>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <LangVersion>latest</LangVersion>
+    <Nullable>disable</Nullable>
+    <Deterministic>true</Deterministic>
+    <Version>2.0.0</Version>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+    <FileVersion>2.0.0.0</FileVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="../FlatFile.Delimited.Attributes/**/*.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../FlatFile.Core.Modern/FlatFile.Core.Modern.csproj" />
+    <ProjectReference Include="../FlatFile.Core.Attributes.Modern/FlatFile.Core.Attributes.Modern.csproj" />
+    <ProjectReference Include="../FlatFile.Delimited.Modern/FlatFile.Delimited.Modern.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/FlatFile.Delimited.Attributes/FlatFile.Delimited.Attributes.csproj
+++ b/src/FlatFile.Delimited.Attributes/FlatFile.Delimited.Attributes.csproj
@@ -84,6 +84,63 @@
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\$(Configuration)\$(Framework)\$(AssemblyName).XML</DocumentationFile>
   </PropertyGroup>
+
+
+  <PropertyGroup Condition=" '$(Framework)' == 'NET451' ">
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Framework)' == 'NET452' ">
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Framework)' == 'NET46' ">
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Framework)' == 'NET461' ">
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Framework)' == 'NET462' ">
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Framework)' == 'NET47' ">
+    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Framework)' == 'NET471' ">
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Framework)' == 'NET472' ">
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Framework)' == 'NET48' And '$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\$(Configuration)\$(Framework)\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Framework)' == 'NET48' And '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\$(Configuration)\$(Framework)\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\$(Configuration)\$(Framework)\FlatFile.Delimited.Attributes.XML</DocumentationFile>
+  </PropertyGroup>
+
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/FlatFile.Delimited.Modern/FlatFile.Delimited.Modern.csproj
+++ b/src/FlatFile.Delimited.Modern/FlatFile.Delimited.Modern.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <RootNamespace>FlatFile.Delimited</RootNamespace>
+    <AssemblyName>FlatFile.Delimited</AssemblyName>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <LangVersion>latest</LangVersion>
+    <Nullable>disable</Nullable>
+    <Deterministic>true</Deterministic>
+    <Version>2.0.0</Version>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+    <FileVersion>2.0.0.0</FileVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="../FlatFile.Delimited/**/*.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../FlatFile.Core.Modern/FlatFile.Core.Modern.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/FlatFile.Delimited/FlatFile.Delimited.csproj
+++ b/src/FlatFile.Delimited/FlatFile.Delimited.csproj
@@ -84,6 +84,63 @@
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\$(Configuration)\$(Framework)\FlatFile.Delimited.XML</DocumentationFile>
   </PropertyGroup>
+
+
+  <PropertyGroup Condition=" '$(Framework)' == 'NET451' ">
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Framework)' == 'NET452' ">
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Framework)' == 'NET46' ">
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Framework)' == 'NET461' ">
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Framework)' == 'NET462' ">
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Framework)' == 'NET47' ">
+    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Framework)' == 'NET471' ">
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Framework)' == 'NET472' ">
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Framework)' == 'NET48' And '$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\$(Configuration)\$(Framework)\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Framework)' == 'NET48' And '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\$(Configuration)\$(Framework)\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\$(Configuration)\$(Framework)\FlatFile.Delimited.XML</DocumentationFile>
+  </PropertyGroup>
+
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/FlatFile.Delimited/Implementation/DelimitedLineBuilder.cs
+++ b/src/FlatFile.Delimited/Implementation/DelimitedLineBuilder.cs
@@ -1,10 +1,10 @@
-﻿namespace FlatFile.Delimited.Implementation
+namespace FlatFile.Delimited.Implementation
 {
-    using System.Linq;
+    using System.Text;
     using FlatFile.Core.Base;
 
     public class DelimitedLineBuilder :
-        LineBulderBase<IDelimitedLayoutDescriptor, IDelimitedFieldSettingsContainer>, 
+        LineBulderBase<IDelimitedLayoutDescriptor, IDelimitedFieldSettingsContainer>,
         IDelimitedLineBuilder
     {
         public DelimitedLineBuilder(IDelimitedLayoutDescriptor descriptor)
@@ -14,11 +14,22 @@
 
         public override string BuildLine<T>(T entry)
         {
-            string line = Descriptor.Fields.Aggregate(string.Empty,
-                (current, field) =>
-                    current + (current.Length > 0 ? Descriptor.Delimiter : "") +
-                    GetStringValueFromField(field, field.PropertyInfo.GetValue(entry, null)));
-            return line;
+            var delimiter = Descriptor.Delimiter;
+            var lineBuilder = new StringBuilder();
+            bool isFirst = true;
+
+            foreach (var field in Descriptor.Fields)
+            {
+                if (!isFirst)
+                {
+                    lineBuilder.Append(delimiter);
+                }
+
+                lineBuilder.Append(GetStringValueFromField(field, field.PropertyInfo.GetValue(entry, null)));
+                isFirst = false;
+            }
+
+            return lineBuilder.ToString();
         }
 
         protected override string TransformFieldValue(IDelimitedFieldSettingsContainer field, string lineValue)
@@ -26,8 +37,9 @@
             var quotes = Descriptor.Quotes;
             if (!string.IsNullOrEmpty(quotes))
             {
-                lineValue = string.Format("{0}{1}{0}", quotes, lineValue);
+                return quotes + lineValue + quotes;
             }
+
             return lineValue;
         }
     }

--- a/src/FlatFile.Delimited/Implementation/DelimitedLineBuilder.cs
+++ b/src/FlatFile.Delimited/Implementation/DelimitedLineBuilder.cs
@@ -2,6 +2,7 @@ namespace FlatFile.Delimited.Implementation
 {
     using System.Text;
     using FlatFile.Core.Base;
+    using FlatFile.Core.Extensions;
 
     public class DelimitedLineBuilder :
         LineBulderBase<IDelimitedLayoutDescriptor, IDelimitedFieldSettingsContainer>,
@@ -25,7 +26,7 @@ namespace FlatFile.Delimited.Implementation
                     lineBuilder.Append(delimiter);
                 }
 
-                lineBuilder.Append(GetStringValueFromField(field, field.PropertyInfo.GetValue(entry, null)));
+                lineBuilder.Append(GetStringValueFromField(field, PropertyAccessorCache.GetValue(field.PropertyInfo, entry)));
                 isFirst = false;
             }
 

--- a/src/FlatFile.Delimited/Implementation/DelimitedLineParser.cs
+++ b/src/FlatFile.Delimited/Implementation/DelimitedLineParser.cs
@@ -27,19 +27,19 @@ namespace FlatFile.Delimited.Implementation
                 {
                     if (!String.IsNullOrEmpty(Layout.Quotes))
                     {
-                        if (line.AsSpan(linePosition).StartsWith(Layout.Quotes.AsSpan(), StringComparison.InvariantCultureIgnoreCase))
+                        if (line.AsSpan(linePosition).StartsWith(Layout.Quotes.AsSpan(), StringComparison.Ordinal))
                         {
-                            nextDelimiterIndex = line.IndexOf(Layout.Quotes, linePosition + 1, StringComparison.InvariantCultureIgnoreCase);
-                            if (line.Length > nextDelimiterIndex)
+                            nextDelimiterIndex = line.IndexOf(Layout.Quotes, linePosition + 1, StringComparison.Ordinal);
+                            if (nextDelimiterIndex > -1 && line.Length > nextDelimiterIndex)
                             {
-                                nextDelimiterIndex = line.IndexOf(Layout.Delimiter, nextDelimiterIndex, StringComparison.InvariantCultureIgnoreCase);
+                                nextDelimiterIndex = line.IndexOf(Layout.Delimiter, nextDelimiterIndex, StringComparison.Ordinal);
                             }
                         }
                     }
 
                     if (nextDelimiterIndex == -1)
                     {
-                        nextDelimiterIndex = line.IndexOf(Layout.Delimiter, linePosition, StringComparison.InvariantCultureIgnoreCase);
+                        nextDelimiterIndex = line.IndexOf(Layout.Delimiter, linePosition, StringComparison.Ordinal);
                     }
                 }
                 int fieldLength;

--- a/src/FlatFile.Delimited/Implementation/DelimitedLineParser.cs
+++ b/src/FlatFile.Delimited/Implementation/DelimitedLineParser.cs
@@ -66,8 +66,12 @@ namespace FlatFile.Delimited.Implementation
                 return memberValue;
             }
 
-            var value = memberValue.Replace(Layout.Quotes, String.Empty);
-            return value;
+            if (memberValue.IndexOf(Layout.Quotes, StringComparison.Ordinal) < 0)
+            {
+                return memberValue;
+            }
+
+            return memberValue.Replace(Layout.Quotes, string.Empty);
         }
     }
 }

--- a/src/FlatFile.Delimited/Implementation/DelimitedLineParser.cs
+++ b/src/FlatFile.Delimited/Implementation/DelimitedLineParser.cs
@@ -25,8 +25,9 @@ namespace FlatFile.Delimited.Implementation
                 int nextDelimiterIndex = -1;
                 if (line.Length > linePosition + delimiterSize)
                 {
-                    if (!String.IsNullOrEmpty(Layout.Quotes)) {
-                        if (Layout.Quotes.Equals(line.Substring(linePosition, Layout.Quotes.Length)))
+                    if (!String.IsNullOrEmpty(Layout.Quotes))
+                    {
+                        if (line.AsSpan(linePosition).StartsWith(Layout.Quotes.AsSpan(), StringComparison.InvariantCultureIgnoreCase))
                         {
                             nextDelimiterIndex = line.IndexOf(Layout.Quotes, linePosition + 1, StringComparison.InvariantCultureIgnoreCase);
                             if (line.Length > nextDelimiterIndex)

--- a/src/FlatFile.Delimited/Implementation/DelimitedLineParser.cs
+++ b/src/FlatFile.Delimited/Implementation/DelimitedLineParser.cs
@@ -3,6 +3,7 @@ namespace FlatFile.Delimited.Implementation
     using System;
     using FlatFile.Core;
     using FlatFile.Core.Base;
+    using FlatFile.Core.Extensions;
 
     public class DelimitedLineParser :
         LineParserBase<IDelimitedLayoutDescriptor, IDelimitedFieldSettingsContainer>,
@@ -53,7 +54,7 @@ namespace FlatFile.Delimited.Implementation
                 }
                 string fieldValueFromLine = line.Substring(linePosition, fieldLength);
                 var convertedFieldValue = GetFieldValueFromString(field, fieldValueFromLine);
-                field.PropertyInfo.SetValue(entity, convertedFieldValue, null);
+                PropertyAccessorCache.SetValue(field.PropertyInfo, entity, convertedFieldValue);
                 linePosition += fieldLength + (nextDelimiterIndex > -1 ? delimiterSize : 0);
             }
             return entity;

--- a/src/FlatFile.FixedLength.Attributes.Modern/FlatFile.FixedLength.Attributes.Modern.csproj
+++ b/src/FlatFile.FixedLength.Attributes.Modern/FlatFile.FixedLength.Attributes.Modern.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <RootNamespace>FlatFile.FixedLength.Attributes</RootNamespace>
+    <AssemblyName>FlatFile.FixedLength.Attributes</AssemblyName>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <LangVersion>latest</LangVersion>
+    <Nullable>disable</Nullable>
+    <Deterministic>true</Deterministic>
+    <Version>2.0.0</Version>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+    <FileVersion>2.0.0.0</FileVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="../FlatFile.FixedLength.Attributes/**/*.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../FlatFile.Core.Modern/FlatFile.Core.Modern.csproj" />
+    <ProjectReference Include="../FlatFile.Core.Attributes.Modern/FlatFile.Core.Attributes.Modern.csproj" />
+    <ProjectReference Include="../FlatFile.FixedLength.Modern/FlatFile.FixedLength.Modern.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/FlatFile.FixedLength.Attributes/FlatFile.FixedLength.Attributes.csproj
+++ b/src/FlatFile.FixedLength.Attributes/FlatFile.FixedLength.Attributes.csproj
@@ -84,6 +84,63 @@
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\$(Configuration)\$(Framework)\$(AssemblyName).XML</DocumentationFile>
   </PropertyGroup>
+
+
+  <PropertyGroup Condition=" '$(Framework)' == 'NET451' ">
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Framework)' == 'NET452' ">
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Framework)' == 'NET46' ">
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Framework)' == 'NET461' ">
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Framework)' == 'NET462' ">
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Framework)' == 'NET47' ">
+    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Framework)' == 'NET471' ">
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Framework)' == 'NET472' ">
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Framework)' == 'NET48' And '$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\$(Configuration)\$(Framework)\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Framework)' == 'NET48' And '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\$(Configuration)\$(Framework)\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\$(Configuration)\$(Framework)\FlatFile.FixedLength.Attributes.XML</DocumentationFile>
+  </PropertyGroup>
+
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/FlatFile.FixedLength.Modern/FlatFile.FixedLength.Modern.csproj
+++ b/src/FlatFile.FixedLength.Modern/FlatFile.FixedLength.Modern.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <RootNamespace>FlatFile.FixedLength</RootNamespace>
+    <AssemblyName>FlatFile.FixedLength</AssemblyName>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <LangVersion>latest</LangVersion>
+    <Nullable>disable</Nullable>
+    <Deterministic>true</Deterministic>
+    <Version>2.0.0</Version>
+    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+    <FileVersion>2.0.0.0</FileVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="../FlatFile.FixedLength/**/*.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../FlatFile.Core.Modern/FlatFile.Core.Modern.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/FlatFile.FixedLength/FlatFile.FixedLength.csproj
+++ b/src/FlatFile.FixedLength/FlatFile.FixedLength.csproj
@@ -84,6 +84,63 @@
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\$(Configuration)\$(Framework)\FlatFile.FixedLength.XML</DocumentationFile>
   </PropertyGroup>
+
+
+  <PropertyGroup Condition=" '$(Framework)' == 'NET451' ">
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Framework)' == 'NET452' ">
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Framework)' == 'NET46' ">
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Framework)' == 'NET461' ">
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Framework)' == 'NET462' ">
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Framework)' == 'NET47' ">
+    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Framework)' == 'NET471' ">
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Framework)' == 'NET472' ">
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Framework)' == 'NET48' And '$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\$(Configuration)\$(Framework)\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Framework)' == 'NET48' And '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\$(Configuration)\$(Framework)\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\$(Configuration)\$(Framework)\FlatFile.FixedLength.XML</DocumentationFile>
+  </PropertyGroup>
+
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/src/FlatFile.FixedLength/Implementation/FixedLengthLineBuilder.cs
+++ b/src/FlatFile.FixedLength/Implementation/FixedLengthLineBuilder.cs
@@ -1,6 +1,6 @@
 namespace FlatFile.FixedLength.Implementation
 {
-    using System.Linq;
+    using System.Text;
     using FlatFile.Core;
     using FlatFile.Core.Base;
 
@@ -15,9 +15,14 @@ namespace FlatFile.FixedLength.Implementation
 
         public override string BuildLine<T>(T entry)
         {
-            string line = Descriptor.Fields.Aggregate(string.Empty,
-                (current, field) => current + GetStringValueFromField(field, field.PropertyInfo.GetValue(entry, null)));
-            return line;
+            var lineBuilder = new StringBuilder();
+
+            foreach (var field in Descriptor.Fields)
+            {
+                lineBuilder.Append(GetStringValueFromField(field, field.PropertyInfo.GetValue(entry, null)));
+            }
+
+            return lineBuilder.ToString();
         }
 
         protected override string TransformFieldValue(IFixedFieldSettingsContainer field, string lineValue)

--- a/src/FlatFile.FixedLength/Implementation/FixedLengthLineBuilder.cs
+++ b/src/FlatFile.FixedLength/Implementation/FixedLengthLineBuilder.cs
@@ -3,6 +3,7 @@ namespace FlatFile.FixedLength.Implementation
     using System.Text;
     using FlatFile.Core;
     using FlatFile.Core.Base;
+    using FlatFile.Core.Extensions;
 
     public class FixedLengthLineBuilder :
         LineBulderBase<ILayoutDescriptor<IFixedFieldSettingsContainer>, IFixedFieldSettingsContainer>,
@@ -19,7 +20,7 @@ namespace FlatFile.FixedLength.Implementation
 
             foreach (var field in Descriptor.Fields)
             {
-                lineBuilder.Append(GetStringValueFromField(field, field.PropertyInfo.GetValue(entry, null)));
+                lineBuilder.Append(GetStringValueFromField(field, PropertyAccessorCache.GetValue(field.PropertyInfo, entry)));
             }
 
             return lineBuilder.ToString();

--- a/src/FlatFile.FixedLength/Implementation/FixedLengthLineParser.cs
+++ b/src/FlatFile.FixedLength/Implementation/FixedLengthLineParser.cs
@@ -52,8 +52,8 @@ namespace FlatFile.FixedLength.Implementation
         protected override string TransformStringValue(IFixedFieldSettingsContainer fieldSettingsBuilder, string memberValue)
         {
             memberValue = fieldSettingsBuilder.PadLeft
-                ? memberValue.TrimStart(new[] {fieldSettingsBuilder.PaddingChar})
-                : memberValue.TrimEnd(new[] {fieldSettingsBuilder.PaddingChar});
+                ? memberValue.TrimStart(fieldSettingsBuilder.PaddingChar)
+                : memberValue.TrimEnd(fieldSettingsBuilder.PaddingChar);
 
             return memberValue;
         }

--- a/src/FlatFile.FixedLength/Implementation/FixedLengthLineParser.cs
+++ b/src/FlatFile.FixedLength/Implementation/FixedLengthLineParser.cs
@@ -4,6 +4,7 @@ namespace FlatFile.FixedLength.Implementation
 {
     using FlatFile.Core;
     using FlatFile.Core.Base;
+    using FlatFile.Core.Extensions;
 
     public class FixedLengthLineParser :
         LineParserBase<ILayoutDescriptor<IFixedFieldSettingsContainer>, IFixedFieldSettingsContainer>,
@@ -21,7 +22,7 @@ namespace FlatFile.FixedLength.Implementation
             {
                 string fieldValueFromLine = GetValueFromLine(line, linePosition, field);
                 object convertedFieldValue = GetFieldValueFromString(field, fieldValueFromLine);
-                field.PropertyInfo.SetValue(entity, convertedFieldValue, null);
+                PropertyAccessorCache.SetValue(field.PropertyInfo, entity, convertedFieldValue);
                 linePosition += field.Length;
             }
             return entity;

--- a/src/FlatFile.Tests/FlatFile.Tests.csproj
+++ b/src/FlatFile.Tests/FlatFile.Tests.csproj
@@ -31,6 +31,63 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+
+
+  <PropertyGroup Condition=" '$(Framework)' == 'NET451' ">
+    <TargetFrameworkVersion>v4.5.1</TargetFrameworkVersion>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Framework)' == 'NET452' ">
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Framework)' == 'NET46' ">
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Framework)' == 'NET461' ">
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Framework)' == 'NET462' ">
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Framework)' == 'NET47' ">
+    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Framework)' == 'NET471' ">
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Framework)' == 'NET472' ">
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Framework)' == 'NET48' And '$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\$(Configuration)\$(Framework)\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Framework)' == 'NET48' And '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\$(Configuration)\$(Framework)\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <DocumentationFile>bin\$(Configuration)\$(Framework)\FlatFile.Tests.XML</DocumentationFile>
+  </PropertyGroup>
+
   <ItemGroup>
     <Reference Include="FakeItEasy, Version=2.2.0.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c, processorArchitecture=MSIL">
       <HintPath>..\packages\FakeItEasy.2.2.0\lib\net40\FakeItEasy.dll</HintPath>

--- a/tests/FlatFile.Modern.Tests/DelimitedParserTests.cs
+++ b/tests/FlatFile.Modern.Tests/DelimitedParserTests.cs
@@ -1,0 +1,45 @@
+using FlatFile.Delimited.Implementation;
+using Xunit;
+
+namespace FlatFile.Modern.Tests;
+
+public class DelimitedParserTests
+{
+    private sealed class Row
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+    }
+
+    [Fact]
+    public void ParseLine_ParsesQuotedDelimitedRow()
+    {
+        var layout = new DelimitedLayout<Row>()
+            .WithDelimiter(";")
+            .WithQuote("\"")
+            .WithMember(x => x.Id)
+            .WithMember(x => x.Name);
+
+        var parser = new DelimitedLineParser(layout);
+        var row = parser.ParseLine("\"1\";\"Alice\"", new Row());
+
+        Assert.Equal(1, row.Id);
+        Assert.Equal("Alice", row.Name);
+    }
+
+    [Fact]
+    public void ParseLine_UnclosedQuote_DoesNotThrowAndParsesAvailableData()
+    {
+        var layout = new DelimitedLayout<Row>()
+            .WithDelimiter(";")
+            .WithQuote("\"")
+            .WithMember(x => x.Id)
+            .WithMember(x => x.Name);
+
+        var parser = new DelimitedLineParser(layout);
+        var row = parser.ParseLine("\"2;\"Bob\"", new Row());
+
+        Assert.Equal(2, row.Id);
+        Assert.Equal("Bob", row.Name);
+    }
+}

--- a/tests/FlatFile.Modern.Tests/FlatFile.Modern.Tests.csproj
+++ b/tests/FlatFile.Modern.Tests/FlatFile.Modern.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../src/FlatFile.Core.Modern/FlatFile.Core.Modern.csproj" />
+    <ProjectReference Include="../../src/FlatFile.Delimited.Modern/FlatFile.Delimited.Modern.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/FlatFile.Modern.Tests/FlatFile.Modern.Tests.csproj
+++ b/tests/FlatFile.Modern.Tests/FlatFile.Modern.Tests.csproj
@@ -22,5 +22,6 @@
   <ItemGroup>
     <ProjectReference Include="../../src/FlatFile.Core.Modern/FlatFile.Core.Modern.csproj" />
     <ProjectReference Include="../../src/FlatFile.Delimited.Modern/FlatFile.Delimited.Modern.csproj" />
+    <ProjectReference Include="../../src/FlatFile.FixedLength.Modern/FlatFile.FixedLength.Modern.csproj" />
   </ItemGroup>
 </Project>

--- a/tests/FlatFile.Modern.Tests/LineBuilderTests.cs
+++ b/tests/FlatFile.Modern.Tests/LineBuilderTests.cs
@@ -1,0 +1,42 @@
+using FlatFile.Delimited.Implementation;
+using FlatFile.FixedLength.Implementation;
+using Xunit;
+
+namespace FlatFile.Modern.Tests;
+
+public class LineBuilderTests
+{
+    private sealed class Row
+    {
+        public int Id { get; set; }
+        public string Name { get; set; } = string.Empty;
+    }
+
+    [Fact]
+    public void DelimitedLineBuilder_BuildsExpectedLine()
+    {
+        var layout = new DelimitedLayout<Row>()
+            .WithDelimiter(";")
+            .WithQuote("\"")
+            .WithMember(x => x.Id)
+            .WithMember(x => x.Name);
+
+        var builder = new DelimitedLineBuilder(layout);
+        var line = builder.BuildLine(new Row { Id = 10, Name = "Alice" });
+
+        Assert.Equal("\"10\";\"Alice\"", line);
+    }
+
+    [Fact]
+    public void FixedLengthLineBuilder_BuildsExpectedLine()
+    {
+        var layout = new FixedLayout<Row>()
+            .WithMember(x => x.Id, c => c.WithLength(3).WithLeftPadding('0'))
+            .WithMember(x => x.Name, c => c.WithLength(5).WithRightPadding(' '));
+
+        var builder = new FixedLengthLineBuilder(layout);
+        var line = builder.BuildLine(new Row { Id = 7, Name = "AB" });
+
+        Assert.Equal("007AB   ", line);
+    }
+}

--- a/tests/FlatFile.Modern.Tests/ReflectionHelperTests.cs
+++ b/tests/FlatFile.Modern.Tests/ReflectionHelperTests.cs
@@ -1,0 +1,28 @@
+using FlatFile.Core.Extensions;
+using Xunit;
+
+namespace FlatFile.Modern.Tests;
+
+public class ReflectionHelperTests
+{
+    private sealed class Sample
+    {
+        public int Value { get; }
+        public Sample() { Value = 42; }
+        public Sample(int value) { Value = value; }
+    }
+
+    [Fact]
+    public void CreateInstance_Cached_DefaultConstructor_Works()
+    {
+        var instance = (Sample)ReflectionHelper.CreateInstance(typeof(Sample), cached: true)!;
+        Assert.Equal(42, instance.Value);
+    }
+
+    [Fact]
+    public void CreateInstance_Cached_WithArguments_Works()
+    {
+        var instance = (Sample)ReflectionHelper.CreateInstance(typeof(Sample), cached: true, 7)!;
+        Assert.Equal(7, instance.Value);
+    }
+}

--- a/tests/FlatFile.Modern.Tests/TypeChangeExtensionsTests.cs
+++ b/tests/FlatFile.Modern.Tests/TypeChangeExtensionsTests.cs
@@ -1,0 +1,25 @@
+using System;
+using FlatFile.Core.Extensions;
+using Xunit;
+
+namespace FlatFile.Modern.Tests;
+
+public class TypeChangeExtensionsTests
+{
+    [Fact]
+    public void Convert_UsesInvariantCulture_ForDecimal()
+    {
+        var value = (decimal)"1234.56".Convert(typeof(decimal));
+        Assert.Equal(1234.56m, value);
+    }
+
+    [Fact]
+    public void Convert_HandlesNullableAndEnum()
+    {
+        var nullValue = (int?)"".Convert(typeof(int?));
+        var day = (DayOfWeek)"friday".Convert(typeof(DayOfWeek));
+
+        Assert.Null(nullValue);
+        Assert.Equal(DayOfWeek.Friday, day);
+    }
+}


### PR DESCRIPTION
### Motivation

- Move the repository to a modern-only strategy targeting .NET 8 and prepare a v2 breaking release. 
- Replace legacy build matrix and msbuild/psake-based pipeline with SDK-style projects and `dotnet`-based tooling. 
- Improve runtime performance and reduce allocations in core reflection/conversion/parser paths.

### Description

- Added new SDK-style projects under `src/*/*.Modern` for `FlatFile.Core`, `Core.Attributes`, `Delimited`, `FixedLength` and their attribute variants targeting `net8.0` with version `2.0.0` and a `Directory.Build.props` to centralize package metadata and README packaging.
- Implemented runtime improvements in core code: replaced reflection `DynamicInvoke` cache with compiled expression factories and `ConcurrentDictionary` caches in `ReflectionHelper`, added converter caching and invariant-culture conversion in `TypeChangeExtensions`, and small parser/trim optimizations in `DelimitedLineParser` and `FixedLengthLineParser`.
- Updated build automation: converted `assets/psake-common.ps1` tasks to use `dotnet restore/clean/build` for modern projects, added `docs/modernization-plan.md`, and updated `README.md` to document modernization and NuGet publishing.
- Added GitHub Actions workflows: `.github/workflows/ci.yml` to run `dotnet build` for modern projects on push/PR and `.github/workflows/publish-nuget.yml` to `dotnet pack` and push packages to NuGet on `master` (uses `NUGET_API_KEY` secret and generates package version `2.0.<run_number>`).

### Testing

- No existing unit tests were modified as part of this change and no automated unit-test runs were executed in this PR.
- A CI workflow (`CI`) was added that will run `dotnet build` for the modern projects on pushes and pull requests, but this workflow was added (not executed) by the change itself.
- A publish workflow (`Publish NuGet (v2)`) was added to pack and push `.Modern` projects; it validates that `NUGET_API_KEY` is configured before publishing.
- Local or CI build validation should be performed after adding the repository `NUGET_API_KEY` secret and/or on subsequent pushes to verify packaging and publishing steps.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4a78526ac832dbfff707bceac4c6c)